### PR TITLE
Track ERC4626 unit exchange rates on vault

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,42 @@
+name: Deploy subgraph
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: choice
+        options:
+          - arbitrum-one
+          - arbitrum_sepolia
+          - avalanche
+          - base
+          - bsc
+          - mainnet
+          - flare
+          - mumbai
+          - oasis_sapphire
+          - matic
+          - sepolia
+          - songbird
+          - linea
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix develop -c rainix-sol-prelude
+      - run: ./prep-ethgild.sh
+      - run: nix develop -c graph codegen
+      - run: nix develop -c graph build --network ${{ inputs.network }}
+      - run: nix develop -c goldsky login --token ${{ secrets.CI_GOLDSKY_TOKEN }}
+      # Check if the repo is clean before deploying.
+      - run: git diff --exit-code -- . ":(exclude)subgraph.yaml"
+      - run: >
+          nix develop -c goldsky subgraph deploy "sft-${{ inputs.network }}/$(date -Idate)-$(openssl rand -hex 2)"
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data
 .bin
 tests/.docker
 tests/.latest.json
+.pre-commit-config.yaml

--- a/abis/ERC4626.json
+++ b/abis/ERC4626.json
@@ -1,0 +1,65 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -75,16 +91,58 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741023058,
-        "narHash": "sha256-LSd/8CBlpDLjci5ANFJjP0w+dGdY/mqKsyUfhjGwnfs=",
+        "lastModified": 1773213477,
+        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "66becfe20b7e688b8f2e5774609c4436cf202ba0",
+        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
         "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1774104215,
+        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "rainix",
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -102,7 +160,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs-old": {
       "locked": {
         "lastModified": 1749104371,
         "narHash": "sha256-m2NmOPd6XgBiskmUq/BS9Xxuf3z0ebnGVfSKNAO5NEM=",
@@ -114,10 +172,42 @@
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
+        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1776017067,
+        "narHash": "sha256-oEp8fqJweZd5doqvH/aBAtc6NzZh+fh0tOhR09gQXck=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a5a7cf16648d79134eb4da0e3354b08913917b2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -133,13 +223,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
-        "lastModified": 1748662220,
-        "narHash": "sha256-7gGa49iB9nCnFk4h/g9zwjlQAyjtpgcFkODjcOQS0Es=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59138c7667b7970d205d6a05a8bfa2d78caa3643",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
@@ -153,16 +243,18 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-old": "nixpkgs-old",
         "rust-overlay": "rust-overlay",
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1749284231,
-        "narHash": "sha256-2pxLmguxgvcIaoCrxrrJaod+Sen/HjULnibdjogNp14=",
+        "lastModified": 1776019532,
+        "narHash": "sha256-0aMnHCZ2fR0+ZwuRHFouYYUQqYL/dSp5cOgka0m6vE4=",
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "f3ef7c9b21db154d6e57858aa2f59ce40e6677bb",
+        "rev": "9babaac787d1e1119609b0d89c33a6b42249c066",
         "type": "github"
       },
       "original": {
@@ -179,14 +271,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1749091064,
-        "narHash": "sha256-TGtYjzRX0sueFhwYsnNNFF5TTKnpnloznpIghLzxeXo=",
+        "lastModified": 1773216618,
+        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "12419593ce78f2e8e1e89a373c6515885e218acb",
+        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
         "type": "github"
       },
       "original": {
@@ -198,15 +290,15 @@
     "solc": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1748780655,
-        "narHash": "sha256-mradCdMvjXwKd7kVFACB/d1CP2LLCyEgUu4vJCSzNLU=",
+        "lastModified": 1772085240,
+        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "3b6f3223ace5a7bc400b01a434d86bb1cb2593fb",
+        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
         "type": "github"
       },
       "original": {
@@ -218,13 +310,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-U5ckttxwKO13gIKggel6iybG5oTDbSidPR5nH3Gs+kY=",
+        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/30a3695/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/30a3695/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -82,6 +82,14 @@ type OffchainAssetReceiptVault @entity {
   "Wrapped ERC20 token transfers for this vault (wallet-to-wallet)"
   wrappedTokenTransfers: [WrappedTokenTransfer!]
     @derivedFrom(field: "offchainAssetReceiptVault")
+  "Underlying assets per 1e18 wrapped shares (ERC4626 convertToAssets(1e18))"
+  assetsPerShare: BigInt
+  "Wrapped shares per 1e18 underlying assets (ERC4626 convertToShares(1e18))"
+  sharesPerAsset: BigInt
+  "Block when wrapped exchange rates were last updated"
+  exchangeRateBlock: BigInt
+  "Timestamp when wrapped exchange rates were last updated"
+  exchangeRateTimestamp: BigInt
 }
 
 type Authorizer @entity {
@@ -500,7 +508,7 @@ type WrappedTokenTransfer @entity {
   from: Bytes!
   "Recipient address"
   to: Bytes!
-  "Transfer amount (18 decimals)"
+  "Transfer amount (18 decimals, wrapped ERC4626 shares)"
   value: BigInt!
   "Block number of the transaction"
   blockNumber: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -79,6 +79,14 @@ type OffchainAssetReceiptVault @entity {
   hashCount: BigInt!
   "Token holders"
   tokenHolders: [TokenHolder!] @derivedFrom(field: "offchainAssetReceiptVault")
+  "Count of TokenHolder entities with balance > 0"
+  tokenHolderCount: BigInt!
+  "Count of SharesTransfer entities for this vault"
+  shareTransferCount: BigInt!
+  "Sum of DepositWithReceipt.amount for this vault"
+  depositVolume: BigInt!
+  "Sum of WithdrawWithReceipt.amount for this vault"
+  withdrawVolume: BigInt!
   "Wrapped ERC20 token transfers for this vault (wallet-to-wallet)"
   wrappedTokenTransfers: [WrappedTokenTransfer!]
     @derivedFrom(field: "offchainAssetReceiptVault")

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -1,4 +1,8 @@
-import { DataSourceContext, json } from "@graphprotocol/graph-ts";
+import {
+  DataSourceContext,
+  json,
+  JSONValueKind,
+} from "@graphprotocol/graph-ts";
 import {
   Certify,
   DepositWithReceipt,
@@ -10,8 +14,11 @@ import {
   User,
   Deployer,
   ReceiptVaultInformation,
-  TokenHolder, SharesTransfer, SharesBalance, Account,
-  Authorizer
+  TokenHolder,
+  SharesTransfer,
+  SharesBalance,
+  Account,
+  Authorizer,
 } from "../generated/schema";
 import { ReceiptTemplate } from "../generated/templates";
 import {
@@ -19,12 +26,12 @@ import {
   ConfiscateShares as ConfiscateSharesEvent,
   ConfiscateReceipt as ConfiscateReceiptEvent,
   Deposit,
-  ReceiptVaultInformation as ReceiptVaultInformationEvent, 
+  ReceiptVaultInformation as ReceiptVaultInformationEvent,
   Transfer,
   Withdraw,
   OffchainAssetReceiptVault as OffchainAssetVaultContract,
   OffchainAssetReceiptVaultInitializedV2,
-  AuthorizerSet
+  AuthorizerSet,
 } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
 import {
   getAccount,
@@ -37,26 +44,30 @@ import {
   stringToArrayBuffer,
   RAIN_META_DOCUMENT,
   BigintToHexString,
-  ZERO_ADDRESS
+  ZERO_ADDRESS,
 } from "./utils";
-import { store, Entity, Value } from '@graphprotocol/graph-ts';
+import { store, Entity, Value } from "@graphprotocol/graph-ts";
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { CBORDecoder } from "@rainprotocol/assemblyscript-cbor";
 
 export function handleAuthorizerSet(event: AuthorizerSet): void {
-  
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
   if (offchainAssetReceiptVault) {
-    if(offchainAssetReceiptVault.activeAuthorizer != null){
-      let previousAuthorizer = Authorizer.load(offchainAssetReceiptVault.activeAuthorizer as string);
-      if (previousAuthorizer && previousAuthorizer.id != event.params.authorizer.toHex()) {
+    if (offchainAssetReceiptVault.activeAuthorizer != null) {
+      let previousAuthorizer = Authorizer.load(
+        offchainAssetReceiptVault.activeAuthorizer as string,
+      );
+      if (
+        previousAuthorizer &&
+        previousAuthorizer.id != event.params.authorizer.toHex()
+      ) {
         previousAuthorizer.isActive = false;
         previousAuthorizer.save();
       }
     }
-    
+
     let authorizer = Authorizer.load(event.params.authorizer.toHex());
     if (authorizer) {
       authorizer.isActive = true;
@@ -72,23 +83,23 @@ export function handleAuthorizerSet(event: AuthorizerSet): void {
 
 export function handleCertify(event: CertifyEvent): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
-  if ( offchainAssetReceiptVault ) {
-    let certify = new Certify(`Certify-${ event.transaction.hash.toHex() }`);
+  if (offchainAssetReceiptVault) {
+    let certify = new Certify(`Certify-${event.transaction.hash.toHex()}`);
     certify.transaction = getTransaction(
       event.block,
-      event.transaction.hash.toHex()
+      event.transaction.hash.toHex(),
     ).id;
     certify.emitter = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     certify.timestamp = event.block.timestamp;
     certify.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
     certify.certifier = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     certify.certifiedUntil = event.params.certifyUntil;
     certify.totalShares = offchainAssetReceiptVault.totalShares;
@@ -96,33 +107,43 @@ export function handleCertify(event: CertifyEvent): void {
     certify.information = event.params.data;
 
     let meta = event.params.data.toHex();
-    if ( meta.includes(BigintToHexString(RAIN_META_DOCUMENT)) ) {
-
+    if (meta.includes(BigintToHexString(RAIN_META_DOCUMENT))) {
       let metaData = event.params.data.toHex().slice(18);
       let data = new CBORDecoder(stringToArrayBuffer(metaData));
       let jsonData = json.try_fromString(data.parse().stringify());
-      if ( jsonData.isOk ) {
+      if (jsonData.isOk && jsonData.value.kind == JSONValueKind.ARRAY) {
         let jsonDataArray = jsonData.value.toArray();
-        if ( jsonDataArray.length ) {
-
+        if (
+          jsonDataArray.length >= 2 &&
+          jsonDataArray[0].kind == JSONValueKind.OBJECT &&
+          jsonDataArray[1].kind == JSONValueKind.OBJECT
+        ) {
+          let hashEntry = jsonDataArray[1].toObject();
 
           certify.save();
           // HashList
-          let hashList = jsonDataArray[ 1 ].toObject().mustGet("0").toString();
-          let hashListArray = hashList.split(",");
-          if ( hashListArray.length ) {
-            for ( let i = 0; i < hashListArray.length; i++ ) {
-              if ( offchainAssetReceiptVault ) {
-                let hash = new Hash(event.transaction.hash.toHex().toString() + "-" + i.toString());
-                hash.owner = event.params.sender.toString();
-                hash.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
-                hash.offchainAssetReceiptVaultDeployer = offchainAssetReceiptVault.deployer.toHex();
-                hash.hash = hashListArray[ i ];
-                hash.timestamp = event.block.timestamp;
-                hash.save();
-                offchainAssetReceiptVault.hashCount =
-                  offchainAssetReceiptVault.hashCount.plus(ONE);
-                offchainAssetReceiptVault.save();
+          let hashListValue = hashEntry.get("0");
+          if (hashListValue) {
+            let hashListArray = hashListValue.toString().split(",");
+            if (hashListArray.length) {
+              for (let i = 0; i < hashListArray.length; i++) {
+                if (offchainAssetReceiptVault) {
+                  let hash = new Hash(
+                    event.transaction.hash.toHex().toString() +
+                      "-" +
+                      i.toString(),
+                  );
+                  hash.owner = event.params.sender.toString();
+                  hash.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
+                  hash.offchainAssetReceiptVaultDeployer =
+                    offchainAssetReceiptVault.deployer.toHex();
+                  hash.hash = hashListArray[i];
+                  hash.timestamp = event.block.timestamp;
+                  hash.save();
+                  offchainAssetReceiptVault.hashCount =
+                    offchainAssetReceiptVault.hashCount.plus(ONE);
+                  offchainAssetReceiptVault.save();
+                }
               }
             }
           }
@@ -131,7 +152,10 @@ export function handleCertify(event: CertifyEvent): void {
     }
 
     certify.save();
-    if ( event.params.forceUntil || event.params.certifyUntil > offchainAssetReceiptVault.certifiedUntil ) {
+    if (
+      event.params.forceUntil ||
+      event.params.certifyUntil > offchainAssetReceiptVault.certifiedUntil
+    ) {
       offchainAssetReceiptVault.certifiedUntil = event.params.certifyUntil;
     }
     offchainAssetReceiptVault.save();
@@ -140,36 +164,36 @@ export function handleCertify(event: CertifyEvent): void {
 
 export function handleConfiscateReceipt(event: ConfiscateReceiptEvent): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
-  if ( offchainAssetReceiptVault ) {
+  if (offchainAssetReceiptVault) {
     let confiscateReceipts = new ConfiscateReceipt(
-      `ConfiscateReceipt-${ event.transaction.hash.toHex() }`
+      `ConfiscateReceipt-${event.transaction.hash.toHex()}`,
     );
     confiscateReceipts.transaction = getTransaction(
       event.block,
-      event.transaction.hash.toHex()
+      event.transaction.hash.toHex(),
     ).id;
     confiscateReceipts.timestamp = event.block.timestamp;
     confiscateReceipts.emitter = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     confiscateReceipts.confiscatee = getAccount(
       event.params.confiscatee.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     confiscateReceipts.confiscator = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
 
     let receipt = getReceipt(
       offchainAssetReceiptVault.id.toString(),
-      event.params.id
+      event.params.id,
     );
 
-    if ( receipt ) {
+    if (receipt) {
       confiscateReceipts.receipt = receipt.id;
     }
 
@@ -182,28 +206,28 @@ export function handleConfiscateReceipt(event: ConfiscateReceiptEvent): void {
 
 export function handleConfiscateShares(event: ConfiscateSharesEvent): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
-  if ( offchainAssetReceiptVault ) {
+  if (offchainAssetReceiptVault) {
     let confiscateShares = new ConfiscateShares(
-      `ConfiscateShares-${ event.transaction.hash.toHex() }`
+      `ConfiscateShares-${event.transaction.hash.toHex()}`,
     );
     confiscateShares.transaction = getTransaction(
       event.block,
-      event.transaction.hash.toHex()
+      event.transaction.hash.toHex(),
     ).id;
     confiscateShares.timestamp = event.block.timestamp;
     confiscateShares.emitter = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     confiscateShares.confiscatee = getAccount(
       event.params.confiscatee.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     confiscateShares.confiscator = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     confiscateShares.confiscated = event.params.confiscated;
     confiscateShares.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
@@ -214,28 +238,28 @@ export function handleConfiscateShares(event: ConfiscateSharesEvent): void {
 
 export function handleDeposit(event: Deposit): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
-  if ( offchainAssetReceiptVault ) {
+  if (offchainAssetReceiptVault) {
     let depositWithReceipt = new DepositWithReceipt(
-      `DepositWithReceipt-${ event.transaction.hash.toHex() }-${ event.params.id.toString() }`
+      `DepositWithReceipt-${event.transaction.hash.toHex()}-${event.params.id.toString()}`,
     );
     depositWithReceipt.timestamp = event.block.timestamp;
     depositWithReceipt.transaction = getTransaction(
       event.block,
-      event.transaction.hash.toHex()
+      event.transaction.hash.toHex(),
     ).id;
     depositWithReceipt.emitter = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     depositWithReceipt.receiver = getAccount(
       event.params.owner.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     depositWithReceipt.caller = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     depositWithReceipt.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
     depositWithReceipt.amount = event.params.shares;
@@ -244,27 +268,27 @@ export function handleDeposit(event: Deposit): void {
 
     let receipt = getReceipt(
       offchainAssetReceiptVault.id.toString(),
-      event.params.id
+      event.params.id,
     );
     let receiptBalance = getReceiptBalance(
       event.address.toHex(),
-      event.params.id
+      event.params.id,
     );
     let contract = OffchainAssetVaultContract.bind(event.address);
     receiptBalance.valueExact = receiptBalance.valueExact.plus(
-      event.params.shares
+      event.params.shares,
     );
     receiptBalance.value = toDecimals(
       receiptBalance.valueExact,
-      contract.decimals()
+      contract.decimals(),
     );
     receiptBalance.account = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     receiptBalance.confiscated = ZERO;
 
-    if ( receipt ) {
+    if (receipt) {
       receipt.shares = receipt.shares.plus(event.params.shares);
       receipt.save();
 
@@ -276,19 +300,19 @@ export function handleDeposit(event: Deposit): void {
 
     let account = getAccount(
       event.params.owner.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     );
-    if ( account ) {
+    if (account) {
       account.hashCount = account.hashCount.plus(ONE);
       account.save();
     }
     let user = User.load(event.params.owner.toHex());
-    if ( user ) {
+    if (user) {
       user.hashCount = user.hashCount.plus(ONE);
       user.save();
     }
     let deployer = Deployer.load(offchainAssetReceiptVault.deployer.toHex());
-    if ( deployer ) {
+    if (deployer) {
       deployer.hashCount = deployer.hashCount.plus(ONE);
       deployer.save();
     }
@@ -296,12 +320,12 @@ export function handleDeposit(event: Deposit): void {
 }
 
 export function handleOffchainAssetVaultInitializedV2(
-  event: OffchainAssetReceiptVaultInitializedV2
+  event: OffchainAssetReceiptVaultInitializedV2,
 ): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
-  if ( offchainAssetReceiptVault ) {
+  if (offchainAssetReceiptVault) {
     offchainAssetReceiptVault.admin = event.params.config.initialAdmin;
     let receiptVaultConfig = event.params.config.receiptVaultConfig;
     // String fields from nested tuples may need explicit conversion
@@ -309,10 +333,11 @@ export function handleOffchainAssetVaultInitializedV2(
     // we need to ensure proper conversion
     offchainAssetReceiptVault.name = receiptVaultConfig.name as string;
     offchainAssetReceiptVault.symbol = receiptVaultConfig.symbol as string;
-    offchainAssetReceiptVault.receiptContractAddress = receiptVaultConfig.receipt;
+    offchainAssetReceiptVault.receiptContractAddress =
+      receiptVaultConfig.receipt;
     offchainAssetReceiptVault.asAccount = getAccount(
       event.address.toHex(),
-      event.address.toHex()
+      event.address.toHex(),
     ).id;
     offchainAssetReceiptVault.save();
   }
@@ -320,67 +345,87 @@ export function handleOffchainAssetVaultInitializedV2(
   context.setString("vault", event.address.toHex());
   ReceiptTemplate.createWithContext(
     event.params.config.receiptVaultConfig.receipt,
-    context
+    context,
   );
 }
 
 export function handleReceiptVaultInformation(
-  event: ReceiptVaultInformationEvent
+  event: ReceiptVaultInformationEvent,
 ): void {
-
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
 
-
   let meta = event.params.vaultInformation.toHex();
-  if ( meta.includes(BigintToHexString(RAIN_META_DOCUMENT)) ) {
-
+  if (meta.includes(BigintToHexString(RAIN_META_DOCUMENT))) {
     let metaData = event.params.vaultInformation.toHex().slice(18);
     let data = new CBORDecoder(stringToArrayBuffer(metaData));
     let jsonData = json.try_fromString(data.parse().stringify());
-    if ( jsonData.isOk ) {
+    if (jsonData.isOk && jsonData.value.kind == JSONValueKind.ARRAY) {
       let jsonDataArray = jsonData.value.toArray();
-      if ( jsonDataArray.length ) {
-        let receiptVaultInformation = new ReceiptVaultInformation(event.transaction.hash.toHex());
+      if (
+        jsonDataArray.length >= 2 &&
+        jsonDataArray[0].kind == JSONValueKind.OBJECT &&
+        jsonDataArray[1].kind == JSONValueKind.OBJECT
+      ) {
+        let primaryInformation = jsonDataArray[0].toObject();
+        let hashEntry = jsonDataArray[1].toObject();
+        let receiptVaultInformation = new ReceiptVaultInformation(
+          event.transaction.hash.toHex(),
+        );
 
         receiptVaultInformation.transaction = getTransaction(
           event.block,
-          event.transaction.hash.toHex()
+          event.transaction.hash.toHex(),
         ).id;
         receiptVaultInformation.timestamp = event.block.timestamp;
-        receiptVaultInformation.offchainAssetReceiptVault = event.address.toHex();
+        receiptVaultInformation.offchainAssetReceiptVault =
+          event.address.toHex();
         receiptVaultInformation.information = event.params.vaultInformation;
         receiptVaultInformation.caller = getAccount(
           event.params.sender.toHex(),
-          event.address.toHex()
+          event.address.toHex(),
         ).id;
         receiptVaultInformation.emitter = getAccount(
           event.params.sender.toHex(),
-          event.address.toHex()
+          event.address.toHex(),
         ).id;
-        receiptVaultInformation.payload = jsonDataArray[ 0 ].toObject().mustGet("0").toString();
-        receiptVaultInformation.magicNumber = jsonDataArray[ 0 ].toObject().mustGet("1").toBigInt();
-        receiptVaultInformation.contentType = jsonDataArray[ 0 ].toObject().mustGet("2").toString();
-        receiptVaultInformation.contentEncoding = jsonDataArray[ 0 ].toObject().mustGet("3").toString();
+        let payload = primaryInformation.get("0");
+        if (payload) receiptVaultInformation.payload = payload.toString();
+        let magicNumber = primaryInformation.get("1");
+        if (magicNumber)
+          receiptVaultInformation.magicNumber = magicNumber.toBigInt();
+        let contentType = primaryInformation.get("2");
+        if (contentType)
+          receiptVaultInformation.contentType = contentType.toString();
+        let contentEncoding = primaryInformation.get("3");
+        if (contentEncoding)
+          receiptVaultInformation.contentEncoding = contentEncoding.toString();
         receiptVaultInformation.save();
 
         //HashList
-        let hashList = jsonDataArray[ 1 ].toObject().mustGet("0").toString();
-        let hashListArray = hashList.split(",");
-        if ( hashListArray.length ) {
-          for ( let i = 0; i < hashListArray.length; i++ ) {
-            if ( offchainAssetReceiptVault ) {
-              let hash = new Hash(event.transaction.hash.toHex().toString() + "-" + i.toString());
-              hash.owner = receiptVaultInformation.caller;
-              hash.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
-              hash.offchainAssetReceiptVaultDeployer = offchainAssetReceiptVault.deployer.toHex();
-              hash.hash = hashListArray[ i ];
-              hash.timestamp = event.block.timestamp;
-              hash.save();
-              offchainAssetReceiptVault.hashCount =
-                offchainAssetReceiptVault.hashCount.plus(ONE);
-              offchainAssetReceiptVault.save();
+        let hashListValue = hashEntry.get("0");
+        if (hashListValue) {
+          let hashListArray = hashListValue.toString().split(",");
+          if (hashListArray.length) {
+            for (let i = 0; i < hashListArray.length; i++) {
+              if (offchainAssetReceiptVault) {
+                let hash = new Hash(
+                  event.transaction.hash.toHex().toString() +
+                    "-" +
+                    i.toString(),
+                );
+                hash.owner = receiptVaultInformation.caller;
+                hash.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
+                hash.offchainAssetReceiptVaultDeployer =
+                  offchainAssetReceiptVault.deployer.toHex();
+                hash.hash = hashListArray[i];
+                hash.timestamp = event.block.timestamp;
+                hash.save();
+                offchainAssetReceiptVault.hashCount =
+                  offchainAssetReceiptVault.hashCount.plus(ONE);
+                offchainAssetReceiptVault.save();
+              }
             }
           }
         }
@@ -401,7 +446,7 @@ function upsertTokenHolder(
   vault: OffchainAssetReceiptVault,
   vaultAddr: Address,
   vaultContract: OffchainAssetVaultContract,
-  user: Address
+  user: Address,
 ): BigInt {
   const id = holderId(vaultAddr, user);
   let th = TokenHolder.load(id);
@@ -420,7 +465,7 @@ function upsertTokenHolder(
 function upsertSharesBalance(
   vault: OffchainAssetReceiptVault,
   accountId: string,
-  exact: BigInt
+  exact: BigInt,
 ): string {
   const id = sharesBalanceId(vault.id, accountId);
   let sb = SharesBalance.load(id);
@@ -481,11 +526,14 @@ export function handleTransfer(event: Transfer): void {
   }
 
   const st = new SharesTransfer(
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
+    event.transaction.hash.toHex() + "-" + event.logIndex.toString(),
   );
 
   st.offchainAssetReceiptVault = vault.id;
-  st.transaction = getTransaction(event.block, event.transaction.hash.toHex()).id;
+  st.transaction = getTransaction(
+    event.block,
+    event.transaction.hash.toHex(),
+  ).id;
   st.timestamp = event.block.timestamp;
 
   // ALWAYS set from/to (zero account when mint/burn)
@@ -506,61 +554,58 @@ export function handleTransfer(event: Transfer): void {
   vault.save();
 }
 
-export function handleWithdraw(
-  event: Withdraw
-): void {
+export function handleWithdraw(event: Withdraw): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    event.address.toHex()
+    event.address.toHex(),
   );
-  if ( offchainAssetReceiptVault ) {
+  if (offchainAssetReceiptVault) {
     let withdrawWithReceipt = new WithdrawWithReceipt(
-      `WithdrawWithReceipt-${ event.transaction.hash.toHex() }-${ event.params.id.toString() }`
+      `WithdrawWithReceipt-${event.transaction.hash.toHex()}-${event.params.id.toString()}`,
     );
     withdrawWithReceipt.amount = event.params.shares;
     withdrawWithReceipt.caller = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     withdrawWithReceipt.emitter = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     withdrawWithReceipt.owner = getAccount(
       event.params.owner.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     withdrawWithReceipt.offchainAssetReceiptVault =
       offchainAssetReceiptVault.id;
     withdrawWithReceipt.timestamp = event.block.timestamp;
     withdrawWithReceipt.transaction = getTransaction(
       event.block,
-      event.transaction.hash.toHex()
+      event.transaction.hash.toHex(),
     ).id;
     withdrawWithReceipt.data = event.params.receiptInformation.toString();
     withdrawWithReceipt.erc1155TokenId = event.params.id.toString();
 
-
     let receiptBalance = getReceiptBalance(
       event.address.toHex(),
-      event.params.id
+      event.params.id,
     );
     let contract = OffchainAssetVaultContract.bind(event.address);
     receiptBalance.valueExact = receiptBalance.valueExact.minus(
-      event.params.shares
+      event.params.shares,
     );
     receiptBalance.value = toDecimals(
       receiptBalance.valueExact,
-      contract.decimals()
+      contract.decimals(),
     );
     receiptBalance.account = getAccount(
       event.params.sender.toHex(),
-      offchainAssetReceiptVault.id
+      offchainAssetReceiptVault.id,
     ).id;
     receiptBalance.confiscated = ZERO;
     receiptBalance.save();
 
     let receipt = getReceipt(offchainAssetReceiptVault.id, event.params.id);
-    if ( receipt ) {
+    if (receipt) {
       receipt.shares = receipt.shares.minus(event.params.shares);
       receipt.save();
       withdrawWithReceipt.receipt = receipt.id;

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -298,6 +298,10 @@ export function handleDeposit(event: Deposit): void {
     receiptBalance.save();
     depositWithReceipt.save();
 
+    offchainAssetReceiptVault.depositVolume =
+      offchainAssetReceiptVault.depositVolume.plus(event.params.shares);
+    offchainAssetReceiptVault.save();
+
     let account = getAccount(
       event.params.owner.toHex(),
       offchainAssetReceiptVault.id,
@@ -450,6 +454,7 @@ function upsertTokenHolder(
 ): BigInt {
   const id = holderId(vaultAddr, user);
   let th = TokenHolder.load(id);
+  const previousBalance = th != null ? th.balance : ZERO;
   if (th == null) {
     th = new TokenHolder(id);
     th.offchainAssetReceiptVault = vault.id;
@@ -459,6 +464,13 @@ function upsertTokenHolder(
   const bal = vaultContract.balanceOf(user);
   th.balance = bal;
   th.save();
+
+  if (previousBalance.equals(ZERO) && bal.gt(ZERO)) {
+    vault.tokenHolderCount = vault.tokenHolderCount.plus(ONE);
+  } else if (previousBalance.gt(ZERO) && bal.equals(ZERO)) {
+    vault.tokenHolderCount = vault.tokenHolderCount.minus(ONE);
+  }
+
   return bal;
 }
 
@@ -551,6 +563,7 @@ export function handleTransfer(event: Transfer): void {
   st.value = toDecimals(event.params.value, 18);
 
   st.save();
+  vault.shareTransferCount = vault.shareTransferCount.plus(ONE);
   vault.save();
 }
 
@@ -612,5 +625,9 @@ export function handleWithdraw(event: Withdraw): void {
     }
 
     withdrawWithReceipt.save();
+
+    offchainAssetReceiptVault.withdrawVolume =
+      offchainAssetReceiptVault.withdrawVolume.plus(event.params.shares);
+    offchainAssetReceiptVault.save();
   }
 }

--- a/src/Receipt.ts
+++ b/src/Receipt.ts
@@ -1,8 +1,8 @@
-import { dataSource, json } from "@graphprotocol/graph-ts";
+import { dataSource, json, JSONValueKind } from "@graphprotocol/graph-ts";
 import {
   Hash,
   OffchainAssetReceiptVault,
-  ReceiptInformation
+  ReceiptInformation,
 } from "../generated/schema";
 import { ReceiptInformation as ReceiptInformationEvent } from "../generated/templates/ReceiptTemplate/Receipt";
 import {
@@ -12,83 +12,97 @@ import {
   getTransaction,
   ONE,
   RAIN_META_DOCUMENT,
-  stringToArrayBuffer
+  stringToArrayBuffer,
 } from "./utils";
 import { CBORDecoder } from "@rainprotocol/assemblyscript-cbor";
 
 export function handleReceiptInformation(event: ReceiptInformationEvent): void {
   let context = dataSource.context();
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
-    context.getString("vault")
+    context.getString("vault"),
   );
-  if ( offchainAssetReceiptVault ) {
+  if (offchainAssetReceiptVault) {
     let meta = event.params.information.toHex();
 
-    if ( meta.includes(BigintToHexString(RAIN_META_DOCUMENT)) ) {
-
+    if (meta.includes(BigintToHexString(RAIN_META_DOCUMENT))) {
       let metaData = event.params.information.toHex().slice(18);
       let data = new CBORDecoder(stringToArrayBuffer(metaData));
       let jsonData = json.try_fromString(data.parse().stringify());
-      if ( jsonData.isOk ) {
+      if (jsonData.isOk && jsonData.value.kind == JSONValueKind.ARRAY) {
         let jsonDataArray = jsonData.value.toArray();
-        if ( jsonDataArray.length ) {
+        if (
+          jsonDataArray.length >= 2 &&
+          jsonDataArray[0].kind == JSONValueKind.OBJECT &&
+          jsonDataArray[1].kind == JSONValueKind.OBJECT
+        ) {
+          let primaryInformation = jsonDataArray[0].toObject();
+          let hashEntry = jsonDataArray[1].toObject();
           let receiptInformation = new ReceiptInformation(
             `ReceiptInformation-${
               offchainAssetReceiptVault.id
-            }-${ event.params.id.toString() }-${ event.transaction.hash.toHex() }`
+            }-${event.params.id.toString()}-${event.transaction.hash.toHex()}`,
           );
           receiptInformation.transaction = getTransaction(
             event.block,
-            event.transaction.hash.toHex()
+            event.transaction.hash.toHex(),
           ).id;
           receiptInformation.timestamp = event.block.timestamp;
-          receiptInformation.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
+          receiptInformation.offchainAssetReceiptVault =
+            offchainAssetReceiptVault.id;
           receiptInformation.information = event.params.information;
           receiptInformation.caller = getAccount(
             event.params.sender.toHex(),
-            offchainAssetReceiptVault.id
+            offchainAssetReceiptVault.id,
           ).id;
           receiptInformation.emitter = getAccount(
             event.params.sender.toHex(),
-            offchainAssetReceiptVault.id
+            offchainAssetReceiptVault.id,
           ).id;
           receiptInformation.receipt = getReceipt(
             offchainAssetReceiptVault.id,
-            event.params.id
+            event.params.id,
           ).id;
-          if ( jsonDataArray[ 0 ].toObject().get("0") )
-            receiptInformation.payload = jsonDataArray[ 0 ].toObject().mustGet("0").toString();
-          if ( jsonDataArray[ 0 ].toObject().get("1") )
-            receiptInformation.magicNumber = jsonDataArray[ 0 ].toObject().mustGet("1").toBigInt();
-          if ( jsonDataArray[ 0 ].toObject().get("2") )
-            receiptInformation.contentType = jsonDataArray[ 0 ].toObject().mustGet("2").toString();
-          if ( jsonDataArray[ 0 ].toObject().get("3") )
-            receiptInformation.contentEncoding = jsonDataArray[ 0 ].toObject().mustGet("3").toString();
+          let payload = primaryInformation.get("0");
+          if (payload) receiptInformation.payload = payload.toString();
+          let magicNumber = primaryInformation.get("1");
+          if (magicNumber)
+            receiptInformation.magicNumber = magicNumber.toBigInt();
+          let contentType = primaryInformation.get("2");
+          if (contentType)
+            receiptInformation.contentType = contentType.toString();
+          let contentEncoding = primaryInformation.get("3");
+          if (contentEncoding)
+            receiptInformation.contentEncoding = contentEncoding.toString();
           // Access the value and set it to receiptInformation.schema
-          if ( jsonDataArray[ 0 ].toObject().get("18422230091423500849") )
-            receiptInformation.schema = jsonDataArray[ 0 ].toObject().mustGet("18422230091423500849").toString();
+          let schema = primaryInformation.get("18422230091423500849");
+          if (schema) receiptInformation.schema = schema.toString();
 
           receiptInformation.save();
 
           //HashList
-          let hashList = jsonDataArray[ 1 ].toObject().mustGet("0").toString();
+          let hashListValue = hashEntry.get("0");
+          if (hashListValue) {
+            let hashListArray = hashListValue.toString().split(",");
+            if (hashListArray.length) {
+              for (let i = 0; i < hashListArray.length; i++) {
+                if (offchainAssetReceiptVault) {
+                  let hash = new Hash(
+                    event.transaction.hash.toHex().toString() +
+                      "-" +
+                      i.toString(),
+                  );
+                  hash.owner = receiptInformation.caller;
+                  hash.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
+                  hash.offchainAssetReceiptVaultDeployer =
+                    offchainAssetReceiptVault.deployer.toHex();
+                  hash.hash = hashListArray[i];
+                  hash.timestamp = event.block.timestamp;
+                  hash.save();
 
-          let hashListArray = hashList.split(",");
-          if ( hashListArray.length ) {
-            for ( let i = 0; i < hashListArray.length; i++ ) {
-              if ( offchainAssetReceiptVault ) {
-
-                let hash = new Hash(event.transaction.hash.toHex().toString() + "-" + i.toString());
-                hash.owner = receiptInformation.caller;
-                hash.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
-                hash.offchainAssetReceiptVaultDeployer = offchainAssetReceiptVault.deployer.toHex();
-                hash.hash = hashListArray[ i ];
-                hash.timestamp = event.block.timestamp;
-                hash.save();
-
-                offchainAssetReceiptVault.hashCount =
-                  offchainAssetReceiptVault.hashCount.plus(ONE);
-                offchainAssetReceiptVault.save();
+                  offchainAssetReceiptVault.hashCount =
+                    offchainAssetReceiptVault.hashCount.plus(ONE);
+                  offchainAssetReceiptVault.save();
+                }
               }
             }
           }

--- a/src/StoxUnifiedDeployer.ts
+++ b/src/StoxUnifiedDeployer.ts
@@ -1,63 +1,66 @@
+import { Deployment } from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
 import {
-    Deployment,
-  } from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
-  import {
-    Authorizer,
-    Deployer,
-    OffchainAssetReceiptVault
-  } from "../generated/schema";
-  import { OffchainAssetReceiptVaultTemplate, WrappedTokenTemplate } from "../generated/templates";
-  import { OffchainAssetReceiptVault as OffchainAssetReceiptVaultContract } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
-  import { ZERO, ZERO_ADDRESS } from "./utils";
-  import { Address, DataSourceContext } from "@graphprotocol/graph-ts";
+  Authorizer,
+  Deployer,
+  OffchainAssetReceiptVault,
+} from "../generated/schema";
+import {
+  OffchainAssetReceiptVaultTemplate,
+  WrappedTokenTemplate,
+} from "../generated/templates";
+import { OffchainAssetReceiptVault as OffchainAssetReceiptVaultContract } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
+import { ZERO, ZERO_ADDRESS } from "./utils";
+import { Address, DataSourceContext } from "@graphprotocol/graph-ts";
 
+export function handleDeployment(event: Deployment): void {
+  let child = new OffchainAssetReceiptVault(event.params.asset.toHex());
+  child.address = event.params.asset;
+  child.wrappedTokenContractAddress = event.params.wrapper;
+  child.deployBlock = event.block.number;
+  child.deployTimestamp = event.block.timestamp;
+  child.deployer = event.params.sender;
+  child.admin = event.params.sender;
 
-  export function handleDeployment(event: Deployment): void { 
+  child.name = "";
+  child.symbol = "";
+  child.totalShares = ZERO;
+  child.certifiedUntil = ZERO;
+  child.hashCount = ZERO;
+  child.shareHoldersCount = ZERO;
+  child.tokenHolderCount = ZERO;
+  child.shareTransferCount = ZERO;
+  child.depositVolume = ZERO;
+  child.withdrawVolume = ZERO;
+  child.activeAuthorizer = ZERO_ADDRESS;
 
-    let child = new OffchainAssetReceiptVault(event.params.asset.toHex());
-    child.address = event.params.asset;
-    child.wrappedTokenContractAddress = event.params.wrapper;
-    child.deployBlock = event.block.number;
-    child.deployTimestamp = event.block.timestamp;
-    child.deployer = event.params.sender;
-    child.admin = event.params.sender;
-  
-    child.name = "";
-    child.symbol = "";
-    child.totalShares = ZERO;
-    child.certifiedUntil = ZERO;
-    child.hashCount = ZERO;
-    child.shareHoldersCount = ZERO;
-    child.activeAuthorizer = ZERO_ADDRESS;
+  // Call receipt() on the asset contract to get the receipt contract address
+  let contract = OffchainAssetReceiptVaultContract.bind(event.params.asset);
+  let receiptResult = contract.try_receipt();
+  if (!receiptResult.reverted) {
+    child.receiptContractAddress = receiptResult.value;
+  }
 
-    // Call receipt() on the asset contract to get the receipt contract address
-    let contract = OffchainAssetReceiptVaultContract.bind(event.params.asset);
-    let receiptResult = contract.try_receipt();
-    if (!receiptResult.reverted) {
-      child.receiptContractAddress = receiptResult.value;
-    }
+  let authorizer = new Authorizer(event.params.asset.toHex());
+  authorizer.address = event.params.asset;
+  authorizer.isActive = true;
+  authorizer.save();
+  child.activeAuthorizer = authorizer.id;
 
-    let authorizer = new Authorizer(event.params.asset.toHex());
-    authorizer.address = event.params.asset;
-    authorizer.isActive = true;
-    authorizer.save();
-    child.activeAuthorizer = authorizer.id;
-    
-    child.save();
-  
-    let deployer = Deployer.load(event.params.sender.toHex());
-    if(!deployer){
-      deployer = new Deployer(event.params.sender.toHex());
-      deployer.hashCount = ZERO;
-      deployer.save();
-    }
-  
-    OffchainAssetReceiptVaultTemplate.create(event.params.asset);
+  child.save();
 
-    let zeroAddr = Address.fromString(ZERO_ADDRESS);
-    if (!event.params.wrapper.equals(zeroAddr)) {
-      let context = new DataSourceContext();
-      context.setString("vaultId", event.params.asset.toHex());
-      WrappedTokenTemplate.createWithContext(event.params.wrapper, context);
-    }
+  let deployer = Deployer.load(event.params.sender.toHex());
+  if (!deployer) {
+    deployer = new Deployer(event.params.sender.toHex());
+    deployer.hashCount = ZERO;
+    deployer.save();
+  }
+
+  OffchainAssetReceiptVaultTemplate.create(event.params.asset);
+
+  let zeroAddr = Address.fromString(ZERO_ADDRESS);
+  if (!event.params.wrapper.equals(zeroAddr)) {
+    let context = new DataSourceContext();
+    context.setString("vaultId", event.params.asset.toHex());
+    WrappedTokenTemplate.createWithContext(event.params.wrapper, context);
+  }
 }

--- a/src/WrappedToken.ts
+++ b/src/WrappedToken.ts
@@ -2,9 +2,33 @@ import {
   OffchainAssetReceiptVault,
   WrappedTokenTransfer,
 } from "../generated/schema";
-import { Transfer as WrappedTransferEvent } from "../generated/templates/WrappedTokenTemplate/ERC20";
-import { getTransaction } from "./utils";
-import { dataSource } from "@graphprotocol/graph-ts";
+import { Transfer as WrappedTransferEvent } from "../generated/templates/WrappedTokenTemplate/ERC4626";
+import { ERC4626 } from "../generated/templates/WrappedTokenTemplate/ERC4626";
+import { getTransaction, ONE_18 } from "./utils";
+import { BigInt, dataSource } from "@graphprotocol/graph-ts";
+
+function updateVaultExchangeRates(
+  vault: OffchainAssetReceiptVault,
+  wrappedToken: ERC4626,
+  blockNumber: BigInt,
+  timestamp: BigInt,
+): void {
+  let assetsPerShareResult = wrappedToken.try_convertToAssets(ONE_18);
+  if (!assetsPerShareResult.reverted) {
+    vault.assetsPerShare = assetsPerShareResult.value;
+  }
+
+  let sharesPerAssetResult = wrappedToken.try_convertToShares(ONE_18);
+  if (!sharesPerAssetResult.reverted) {
+    vault.sharesPerAsset = sharesPerAssetResult.value;
+  }
+
+  if (!assetsPerShareResult.reverted || !sharesPerAssetResult.reverted) {
+    vault.exchangeRateBlock = blockNumber;
+    vault.exchangeRateTimestamp = timestamp;
+    vault.save();
+  }
+}
 
 export function handleWrappedTokenTransfer(event: WrappedTransferEvent): void {
   let vaultId = dataSource.context().getString("vaultId");
@@ -20,6 +44,17 @@ export function handleWrappedTokenTransfer(event: WrappedTransferEvent): void {
   transfer.timestamp = event.block.timestamp;
   transfer.token = event.address;
   transfer.offchainAssetReceiptVault = vault.id;
-  transfer.transaction = getTransaction(event.block, event.transaction.hash.toHex()).id;
+  transfer.transaction = getTransaction(
+    event.block,
+    event.transaction.hash.toHex(),
+  ).id;
   transfer.save();
+
+  let wrappedToken = ERC4626.bind(event.address);
+  updateVaultExchangeRates(
+    vault,
+    wrappedToken,
+    event.block.number,
+    event.block.timestamp,
+  );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,10 @@ export function getAccount(
       tempVault.totalShares = ZERO;
       tempVault.shareHoldersCount = ZERO;
       tempVault.hashCount = ZERO;
+      tempVault.tokenHolderCount = ZERO;
+      tempVault.shareTransferCount = ZERO;
+      tempVault.depositVolume = ZERO;
+      tempVault.withdrawVolume = ZERO;
       tempVault.certifiedUntil = ZERO;
       tempVault.save();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,35 +1,42 @@
-import { Address, BigDecimal, BigInt, ByteArray, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import {
+  Address,
+  BigDecimal,
+  BigInt,
+  ByteArray,
+  Bytes,
+  ethereum,
+} from "@graphprotocol/graph-ts";
 import {
   Account,
   Authorizer,
   OffchainAssetReceiptVault,
   Receipt,
   ReceiptBalance,
-  RoleHolder, TokenHolder,
+  RoleHolder,
+  TokenHolder,
   Transaction,
-  User
+  User,
 } from "../generated/schema";
 
 export const ZERO = BigInt.fromI32(0);
 export const ONE = BigInt.fromI32(1);
+export const ONE_18 = BigInt.fromString("1000000000000000000");
 export const ZERO_BD = BigDecimal.fromString("0");
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-
 export function getAccount(
   address: string,
-  offchainAssetReceiptVault: string
+  offchainAssetReceiptVault: string,
 ): Account {
-  
   let accountId = offchainAssetReceiptVault + "-" + address;
   let account = Account.load(accountId);
-  
+
   // First check if account exists
   if (!account) {
     let vault = OffchainAssetReceiptVault.load(offchainAssetReceiptVault);
-    
+
     account = new Account(accountId);
-    
+
     // If the vault exists, use its ID, otherwise use the provided vault address
     if (vault) {
       account.offchainAssetReceiptVault = vault.id;
@@ -49,27 +56,30 @@ export function getAccount(
       tempVault.hashCount = ZERO;
       tempVault.certifiedUntil = ZERO;
       tempVault.save();
-      
+
       account.offchainAssetReceiptVault = tempVault.id;
     }
-    
+
     account.address = Address.fromHexString(address);
-    account.hashCount = ZERO; 
+    account.hashCount = ZERO;
     account.save();
   }
 
   // Create or load user entity
   let user = User.load(address);
-  if(!user){
+  if (!user) {
     user = new User(address);
     user.hashCount = ZERO;
     user.save();
   }
-  
+
   return account as Account;
 }
 
-export function getTransaction(block: ethereum.Block, hash:string): Transaction {
+export function getTransaction(
+  block: ethereum.Block,
+  hash: string,
+): Transaction {
   let transaction = Transaction.load(hash);
   if (!transaction) {
     transaction = new Transaction(hash);
@@ -83,46 +93,41 @@ export function getTransaction(block: ethereum.Block, hash:string): Transaction 
 export function getRoleHolder(
   authorizer: string,
   address: string,
-  role: string
+  role: string,
 ): RoleHolder {
-  let roleHolder = RoleHolder.load(
-    authorizer + "-" + address + "-" + role
-  );
+  let roleHolder = RoleHolder.load(authorizer + "-" + address + "-" + role);
   if (!roleHolder) {
     let authorizerEntity = Authorizer.load(authorizer);
-    
+
     // Create the role holder regardless of whether the authorizer is linked to a vault
-    roleHolder = new RoleHolder(
-      authorizer + "-" + address + "-" + role
-    );
-    
+    roleHolder = new RoleHolder(authorizer + "-" + address + "-" + role);
+
     // Use the authorizer address as the vault ID if no vault is linked yet
     let vaultId = authorizer;
-    if (authorizerEntity && authorizerEntity.offchainAssetReceiptVault != null) {
+    if (
+      authorizerEntity &&
+      authorizerEntity.offchainAssetReceiptVault != null
+    ) {
       vaultId = authorizerEntity.offchainAssetReceiptVault as string;
     }
-    
+
     roleHolder.account = getAccount(address, vaultId).id;
     roleHolder.authorizer = authorizer;
     roleHolder.role = authorizer + "-" + role;
     roleHolder.activeRoles = [];
     roleHolder.save();
   }
-  
+
   return roleHolder as RoleHolder;
 }
 
 export function getTokenHolder(
   offchainAssetReceiptVault: string,
-  address: string
+  address: string,
 ): TokenHolder {
-  let tokenHolder = TokenHolder.load(
-    offchainAssetReceiptVault + "-" + address
-  );
+  let tokenHolder = TokenHolder.load(offchainAssetReceiptVault + "-" + address);
   if (!tokenHolder) {
-    tokenHolder = new TokenHolder(
-      offchainAssetReceiptVault + "-" + address
-    );
+    tokenHolder = new TokenHolder(offchainAssetReceiptVault + "-" + address);
     tokenHolder.offchainAssetReceiptVault = offchainAssetReceiptVault;
     tokenHolder.address = Address.fromHexString(address);
     tokenHolder.balance = ZERO;
@@ -131,21 +136,33 @@ export function getTokenHolder(
   return tokenHolder as TokenHolder;
 }
 
-export function getReceipt(offchainAssetReceiptVault: string, receiptId: BigInt): Receipt{
-  let receipt = Receipt.load(offchainAssetReceiptVault + "-" + receiptId.toString());
-  if(!receipt){
-    receipt = new Receipt(offchainAssetReceiptVault + "-" + receiptId.toString());
+export function getReceipt(
+  offchainAssetReceiptVault: string,
+  receiptId: BigInt,
+): Receipt {
+  let receipt = Receipt.load(
+    offchainAssetReceiptVault + "-" + receiptId.toString(),
+  );
+  if (!receipt) {
+    receipt = new Receipt(
+      offchainAssetReceiptVault + "-" + receiptId.toString(),
+    );
     receipt.offchainAssetReceiptVault = offchainAssetReceiptVault;
     receipt.receiptId = receiptId;
     receipt.shares = ZERO;
-    receipt.save(); 
+    receipt.save();
   }
   return receipt as Receipt;
 }
 
-export function getReceiptBalance(contract: string, receiptId: BigInt): ReceiptBalance{
-  let receiptBalance = ReceiptBalance.load(contract + "-" + receiptId.toString());
-  if(!receiptBalance) {
+export function getReceiptBalance(
+  contract: string,
+  receiptId: BigInt,
+): ReceiptBalance {
+  let receiptBalance = ReceiptBalance.load(
+    contract + "-" + receiptId.toString(),
+  );
+  if (!receiptBalance) {
     receiptBalance = new ReceiptBalance(contract + "-" + receiptId.toString());
     receiptBalance.offchainAssetReceiptVault = contract;
     receiptBalance.valueExact = ZERO;
@@ -169,8 +186,8 @@ export function hexToBigint(hex: string): BigInt {
   return BigInt.fromUnsignedBytes(byteArray);
 }
 
-export function BigintToHexString(bigint: BigInt): string{
-  return ByteArray.fromBigInt(bigint).toHexString().toString().slice(0,18)
+export function BigintToHexString(bigint: BigInt): string {
+  return ByteArray.fromBigInt(bigint).toHexString().toString().slice(0, 18);
 }
 
 /**

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -129,7 +129,7 @@ templates:
     name: WrappedTokenTemplate
     network: base
     source:
-      abi: ERC20
+      abi: ERC4626
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -138,8 +138,8 @@ templates:
         - WrappedTokenTransfer
         - Transaction
       abis:
-        - name: ERC20
-          file: ./lib/ethgild/out/ERC20.sol/ERC20.json
+        - name: ERC4626
+          file: ./abis/ERC4626.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleWrappedTokenTransfer

--- a/tests/handleDeployment.test.ts
+++ b/tests/handleDeployment.test.ts
@@ -6,24 +6,19 @@ import {
   afterEach,
   beforeAll,
   clearInBlockStore,
-  dataSourceMock
+  dataSourceMock,
 } from "matchstick-as";
-import {
-  Address,
-  DataSourceContext,
-  Value
-} from "@graphprotocol/graph-ts";
+import { Address, DataSourceContext, Value } from "@graphprotocol/graph-ts";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
 
 describe("Handle Deployment Test", () => {
-
-  const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
 
   beforeAll(() => {
-    let context = new DataSourceContext()
-    context.set('contextVal', Value.fromI32(325))
-    dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
   });
 
   afterEach(() => {
@@ -32,19 +27,27 @@ describe("Handle Deployment Test", () => {
   });
 
   test("handle deployment creates OffchainAssetReceiptVault and Authorizer", () => {
-    const sender = Address.fromString("0x1234567890123456789012345678901234567890");
-    const asset = Address.fromString("0x1234567890123456789012345678901234567891");
-    const receipt = Address.fromString("0x1234567890123456789012345678901234567892");
-    const wrapper = Address.fromString("0x1234567890123456789012345678901234567893");
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const asset = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
+    const receipt = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
+    const wrapper = Address.fromString(
+      "0x1234567890123456789012345678901234567893",
+    );
     const contractAddress = Address.fromString(dataSourceAddress);
-    
+
     // Mock the receipt() RPC call
     createMockReceiptFunction(asset, receipt);
     let deploymentEvent = createDeploymentEvent(
       sender,
       asset,
       wrapper,
-      contractAddress
+      contractAddress,
     );
 
     handleDeployment(deploymentEvent);
@@ -59,77 +62,105 @@ describe("Handle Deployment Test", () => {
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "address",
-      asset.toHexString()
+      asset.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "deployer",
-      sender.toHexString()
+      sender.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "admin",
-      sender.toHexString()
+      sender.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "name",
-      ""
+      "",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "symbol",
-      ""
+      "",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "totalShares",
-      "0"
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "certifiedUntil",
-      "0"
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "hashCount",
-      "0"
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "shareHoldersCount",
-      "0"
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "tokenHolderCount",
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "shareTransferCount",
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "depositVolume",
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "withdrawVolume",
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "deployBlock",
-      deploymentEvent.block.number.toString()
+      deploymentEvent.block.number.toString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "deployTimestamp",
-      deploymentEvent.block.timestamp.toString()
+      deploymentEvent.block.timestamp.toString(),
     );
 
     // Verify Authorizer entity was created
@@ -137,50 +168,54 @@ describe("Handle Deployment Test", () => {
       "Authorizer",
       asset.toHexString(),
       "address",
-      asset.toHexString()
+      asset.toHexString(),
     );
 
-    assert.fieldEquals(
-      "Authorizer",
-      asset.toHexString(),
-      "isActive",
-      "true"
-    );
+    assert.fieldEquals("Authorizer", asset.toHexString(), "isActive", "true");
 
     // Verify activeAuthorizer is set correctly
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "activeAuthorizer",
-      asset.toHexString()
+      asset.toHexString(),
     );
 
     // Verify Deployer entity was created
-    assert.fieldEquals(
-      "Deployer",
-      sender.toHexString(),
-      "hashCount",
-      "0"
-    );
+    assert.fieldEquals("Deployer", sender.toHexString(), "hashCount", "0");
   });
 
   test("handle deployment with existing deployer does not create duplicate", () => {
-    const sender = Address.fromString("0x1234567890123456789012345678901234567890");
-    const asset1 = Address.fromString("0x1234567890123456789012345678901234567891");
-    const receipt1 = Address.fromString("0x1234567890123456789012345678901234567892");
-    const wrapper1 = Address.fromString("0x1234567890123456789012345678901234567893");
-    const asset2 = Address.fromString("0x1234567890123456789012345678901234567894");
-    const receipt2 = Address.fromString("0x1234567890123456789012345678901234567895");
-    const wrapper2 = Address.fromString("0x1234567890123456789012345678901234567896");
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const asset1 = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
+    const receipt1 = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
+    const wrapper1 = Address.fromString(
+      "0x1234567890123456789012345678901234567893",
+    );
+    const asset2 = Address.fromString(
+      "0x1234567890123456789012345678901234567894",
+    );
+    const receipt2 = Address.fromString(
+      "0x1234567890123456789012345678901234567895",
+    );
+    const wrapper2 = Address.fromString(
+      "0x1234567890123456789012345678901234567896",
+    );
     const contractAddress = Address.fromString(dataSourceAddress);
-    
+
     // First deployment
     createMockReceiptFunction(asset1, receipt1);
     let deploymentEvent1 = createDeploymentEvent(
       sender,
       asset1,
       wrapper1,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent1);
 
@@ -190,7 +225,7 @@ describe("Handle Deployment Test", () => {
       sender,
       asset2,
       wrapper2,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent2);
 
@@ -204,35 +239,51 @@ describe("Handle Deployment Test", () => {
       "OffchainAssetReceiptVault",
       asset1.toHexString(),
       "deployer",
-      sender.toHexString()
+      sender.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset2.toHexString(),
       "deployer",
-      sender.toHexString()
+      sender.toHexString(),
     );
   });
 
   test("handle deployment with different senders creates separate deployers", () => {
-    const sender1 = Address.fromString("0x1234567890123456789012345678901234567890");
-    const sender2 = Address.fromString("0x1234567890123456789012345678901234567899");
-    const asset1 = Address.fromString("0x1234567890123456789012345678901234567891");
-    const receipt1 = Address.fromString("0x1234567890123456789012345678901234567892");
-    const wrapper1 = Address.fromString("0x1234567890123456789012345678901234567893");
-    const asset2 = Address.fromString("0x1234567890123456789012345678901234567894");
-    const receipt2 = Address.fromString("0x1234567890123456789012345678901234567895");
-    const wrapper2 = Address.fromString("0x1234567890123456789012345678901234567896");
+    const sender1 = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const sender2 = Address.fromString(
+      "0x1234567890123456789012345678901234567899",
+    );
+    const asset1 = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
+    const receipt1 = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
+    const wrapper1 = Address.fromString(
+      "0x1234567890123456789012345678901234567893",
+    );
+    const asset2 = Address.fromString(
+      "0x1234567890123456789012345678901234567894",
+    );
+    const receipt2 = Address.fromString(
+      "0x1234567890123456789012345678901234567895",
+    );
+    const wrapper2 = Address.fromString(
+      "0x1234567890123456789012345678901234567896",
+    );
     const contractAddress = Address.fromString(dataSourceAddress);
-    
+
     // First deployment by sender1
     createMockReceiptFunction(asset1, receipt1);
     let deploymentEvent1 = createDeploymentEvent(
       sender1,
       asset1,
       wrapper1,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent1);
 
@@ -242,7 +293,7 @@ describe("Handle Deployment Test", () => {
       sender2,
       asset2,
       wrapper2,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent2);
 
@@ -256,14 +307,14 @@ describe("Handle Deployment Test", () => {
       "OffchainAssetReceiptVault",
       asset1.toHexString(),
       "deployer",
-      sender1.toHexString()
+      sender1.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset2.toHexString(),
       "deployer",
-      sender2.toHexString()
+      sender2.toHexString(),
     );
   });
 });

--- a/tests/handleDeposit.test.ts
+++ b/tests/handleDeposit.test.ts
@@ -1,21 +1,27 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock,
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
 } from "matchstick-as";
 import {
-    Address,
-    Bytes,
-    DataSourceContext,
-    Value,
-    BigInt
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
 } from "@graphprotocol/graph-ts";
-import { createDepositEvent, createNewCloneEvent, createMockERC20Functions, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+import {
+  createDepositEvent,
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
@@ -23,136 +29,172 @@ import { handleDeposit } from "../src/OffchainAssetReceiptVault";
 import { getAccount, getReceipt } from "../src/utils";
 
 describe("Deposit Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  test("handle deposit", () => {
+    const depositor = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
 
-    test("handle deposit", () => {
-        const depositor = Address.fromString("0x1234567890123456789012345678901234567890");
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      depositor,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(depositor, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      depositor,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent = createNewCloneEvent(depositor, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    createMockERC20Functions(assetVaultClone);
 
-        createMockERC20Functions(assetVaultClone);
+    const depositEvent = createDepositEvent(
+      depositor,
+      depositor,
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleDeposit(depositEvent);
 
-        const depositEvent = createDepositEvent(
-            depositor,
-            depositor,
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleDeposit(depositEvent);
+    assert.entityCount("DepositWithReceipt", 1);
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
 
-        assert.entityCount("DepositWithReceipt", 1);
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
+    const depositWithReceiptId = `DepositWithReceipt-${depositEvent.transaction.hash.toHex()}-${depositEvent.params.id.toString()}`;
+    const emitter = getAccount(depositor.toHex(), assetVaultClone.toHex()).id;
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "id",
+      depositWithReceiptId,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "timestamp",
+      depositEvent.block.timestamp.toString(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "transaction",
+      depositEvent.transaction.hash.toHex(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "emitter",
+      emitter,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "receiver",
+      emitter,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "caller",
+      emitter,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "amount",
+      depositEvent.params.shares.toString(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "data",
+      depositEvent.params.receiptInformation.toString(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "erc1155TokenId",
+      depositEvent.params.id.toString(),
+    );
 
-        const depositWithReceiptId = `DepositWithReceipt-${depositEvent.transaction.hash.toHex()}-${depositEvent.params.id.toString()}`;
-        const emitter = getAccount(depositor.toHex(), assetVaultClone.toHex()).id;
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "id",
-            depositWithReceiptId
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "timestamp",
-            depositEvent.block.timestamp.toString()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "transaction",
-            depositEvent.transaction.hash.toHex()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "emitter",
-            emitter
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "receiver",
-            emitter
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "caller",
-            emitter
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "amount",
-            depositEvent.params.shares.toString()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "data",
-            depositEvent.params.receiptInformation.toString()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "erc1155TokenId",
-            depositEvent.params.id.toString()
-        );
+    const currentReceipt = getReceipt(
+      assetVaultClone.toHex(),
+      depositEvent.params.id,
+    );
+    assert.fieldEquals(
+      "Receipt",
+      currentReceipt.id,
+      "receiptId",
+      depositEvent.params.id.toString(),
+    );
+    assert.fieldEquals(
+      "Receipt",
+      currentReceipt.id,
+      "shares",
+      depositEvent.params.shares.toString(),
+    );
+    assert.fieldEquals(
+      "Receipt",
+      currentReceipt.id,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
 
-        const currentReceipt = getReceipt(assetVaultClone.toHex(), depositEvent.params.id);
-        assert.fieldEquals(
-            "Receipt",
-            currentReceipt.id,
-            "receiptId",
-            depositEvent.params.id.toString()
-        );
-        assert.fieldEquals(
-            "Receipt",
-            currentReceipt.id,
-            "shares",
-            depositEvent.params.shares.toString()
-        );
-        assert.fieldEquals(
-            "Receipt",
-            currentReceipt.id,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );  
-    })
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "depositVolume",
+      depositEvent.params.shares.toString(),
+    );
 
-})
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "withdrawVolume",
+      "0",
+    );
+  });
+});

--- a/tests/handleTransfer.test.ts
+++ b/tests/handleTransfer.test.ts
@@ -1,0 +1,175 @@
+import {
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
+} from "matchstick-as";
+import {
+  Address,
+  DataSourceContext,
+  Value,
+  BigInt,
+} from "@graphprotocol/graph-ts";
+import {
+  createDeploymentEvent,
+  createMockERC20Functions,
+  createMockReceiptFunction,
+  createTransferEvent,
+  createMockBalanceOfFunction,
+  createMockTotalSupplyFunction,
+} from "./mock.test";
+import { handleDeployment } from "../src/StoxUnifiedDeployer";
+import { handleTransfer } from "../src/OffchainAssetReceiptVault";
+import { ZERO, ZERO_ADDRESS } from "../src/utils";
+
+describe("Transfer Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
+
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
+
+  test("handle transfer updates share transfer count and token holder count", () => {
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const sender = Address.fromString(
+      "0x0000000000000000000000000000000000eeeeee",
+    );
+    const recipient = Address.fromString(
+      "0x0000000000000000000000000000000000ffffff",
+    );
+    const zero = Address.fromString(ZERO_ADDRESS);
+
+    createMockReceiptFunction(assetVaultClone, receipt);
+    handleDeployment(
+      createDeploymentEvent(
+        deployer,
+        assetVaultClone,
+        wrapper,
+        Address.fromString(dataSourceAddress),
+      ),
+    );
+    createMockERC20Functions(assetVaultClone);
+
+    const transferAmount = BigInt.fromString("1000000000000000000");
+    const senderBalanceAfter = BigInt.fromString("500000000000000000");
+    const recipientBalanceAfter = transferAmount;
+
+    createMockTotalSupplyFunction(assetVaultClone, transferAmount);
+    createMockBalanceOfFunction(assetVaultClone, sender, senderBalanceAfter);
+    createMockBalanceOfFunction(
+      assetVaultClone,
+      recipient,
+      recipientBalanceAfter,
+    );
+
+    handleTransfer(
+      createTransferEvent(sender, recipient, transferAmount, assetVaultClone),
+    );
+
+    assert.entityCount("SharesTransfer", 1);
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "1",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "2",
+    );
+
+    createMockBalanceOfFunction(assetVaultClone, sender, ZERO);
+    createMockTotalSupplyFunction(assetVaultClone, recipientBalanceAfter);
+
+    handleTransfer(
+      createTransferEvent(
+        sender,
+        recipient,
+        senderBalanceAfter,
+        assetVaultClone,
+      ),
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "2",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "1",
+    );
+
+    createMockBalanceOfFunction(assetVaultClone, recipient, ZERO);
+    createMockTotalSupplyFunction(assetVaultClone, ZERO);
+
+    handleTransfer(
+      createTransferEvent(
+        recipient,
+        zero,
+        recipientBalanceAfter,
+        assetVaultClone,
+      ),
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "3",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "0",
+    );
+
+    createMockBalanceOfFunction(assetVaultClone, recipient, transferAmount);
+    createMockTotalSupplyFunction(assetVaultClone, transferAmount);
+
+    handleTransfer(
+      createTransferEvent(zero, recipient, transferAmount, assetVaultClone),
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "4",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "1",
+    );
+  });
+});

--- a/tests/handleWithdraw.test.ts
+++ b/tests/handleWithdraw.test.ts
@@ -1,188 +1,221 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
 } from "matchstick-as";
 import {
-    Address,
-    Bytes,
-    DataSourceContext,
-    Value,
-    BigInt
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
 } from "@graphprotocol/graph-ts";
-import { createDepositEvent, createNewCloneEvent, createMockERC20Functions, createWithdrawEvent, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+import {
+  createDepositEvent,
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createWithdrawEvent,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
-import { handleDeposit, handleWithdraw } from "../src/OffchainAssetReceiptVault";
+import {
+  handleDeposit,
+  handleWithdraw,
+} from "../src/OffchainAssetReceiptVault";
 import { getAccount, getReceiptBalance } from "../src/utils";
 
-
 describe("Withdraw Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  test("handle withdraw", () => {
+    const depositorWithdrawer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
 
-    test("handle withdraw", () => {
-        const depositorWithdrawer = Address.fromString("0x1234567890123456789012345678901234567890");
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      depositorWithdrawer,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(depositorWithdrawer, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      depositorWithdrawer,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent = createNewCloneEvent(depositorWithdrawer, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    createMockERC20Functions(assetVaultClone);
 
-        createMockERC20Functions(assetVaultClone);
+    const depositEvent = createDepositEvent(
+      depositorWithdrawer,
+      depositorWithdrawer,
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleDeposit(depositEvent);
 
-        const depositEvent = createDepositEvent(
-            depositorWithdrawer,
-            depositorWithdrawer,
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleDeposit(depositEvent);
+    assert.entityCount("DepositWithReceipt", 1);
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
 
-        assert.entityCount("DepositWithReceipt", 1);
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
+    const withdrawEvent = createWithdrawEvent(
+      depositorWithdrawer,
+      depositorWithdrawer,
+      depositorWithdrawer,
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleWithdraw(withdrawEvent);
+    assert.entityCount("WithdrawWithReceipt", 1);
 
-        const withdrawEvent = createWithdrawEvent(
-            depositorWithdrawer,
-            depositorWithdrawer,
-            depositorWithdrawer,
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleWithdraw(withdrawEvent);
-        assert.entityCount("WithdrawWithReceipt", 1);
+    const withdrawWithReceiptId = `WithdrawWithReceipt-${withdrawEvent.transaction.hash.toHex()}-${withdrawEvent.params.id.toString()}`;
+    const emitter = getAccount(
+      depositorWithdrawer.toHex(),
+      assetVaultClone.toHex(),
+    ).id;
 
-        const withdrawWithReceiptId = `WithdrawWithReceipt-${withdrawEvent.transaction.hash.toHex()}-${withdrawEvent.params.id.toString()}`;
-        const emitter = getAccount(depositorWithdrawer.toHex(), assetVaultClone.toHex()).id;
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "id",
+      withdrawWithReceiptId,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "id",
-            withdrawWithReceiptId
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "amount",
+      withdrawEvent.params.shares.toString(),
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "amount",
-            withdrawEvent.params.shares.toString()
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "caller",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "caller",
-            emitter
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "emitter",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "emitter",
-            emitter
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "owner",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "owner",
-            emitter
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "data",
+      withdrawEvent.params.receiptInformation.toString(),
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "data",
-            withdrawEvent.params.receiptInformation.toString()
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "erc1155TokenId",
+      withdrawEvent.params.id.toString(),
+    );
+    const receiptBalance = getReceiptBalance(
+      assetVaultClone.toHex(),
+      withdrawEvent.params.id,
+    );
+    assert.fieldEquals("ReceiptBalance", receiptBalance.id, "value", "0.5");
+    assert.fieldEquals(
+      "ReceiptBalance",
+      receiptBalance.id,
+      "valueExact",
+      "500000000000000000",
+    );
+    const withdrawEvent2 = createWithdrawEvent(
+      depositorWithdrawer,
+      depositorWithdrawer,
+      depositorWithdrawer,
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleWithdraw(withdrawEvent2);
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "erc1155TokenId",
-            withdrawEvent.params.id.toString()
-        );
-        const receiptBalance = getReceiptBalance(assetVaultClone.toHex(), withdrawEvent.params.id);
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "value",
-            "0.5"
-        );
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "valueExact",
-            "500000000000000000"
-        );
-        const withdrawEvent2 = createWithdrawEvent(
-            depositorWithdrawer,
-            depositorWithdrawer,
-            depositorWithdrawer,
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleWithdraw(withdrawEvent2);
+    assert.entityCount("WithdrawWithReceipt", 1);
 
-        assert.entityCount("WithdrawWithReceipt", 1);
+    assert.fieldEquals("ReceiptBalance", receiptBalance.id, "value", "0");
 
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "value",
-            "0"
-        );
+    assert.fieldEquals("ReceiptBalance", receiptBalance.id, "valueExact", "0");
 
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "valueExact",
-            "0"
-        );
-    })
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "depositVolume",
+      depositEvent.params.shares.toString(),
+    );
 
-})
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "withdrawVolume",
+      "1000000000000000000",
+    );
+  });
+});

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -1,329 +1,385 @@
-import {
-    NewClone,
-} from "../generated/CloneFactory/CloneFactory";
-import {
-    Deployment,
-} from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
+import { NewClone } from "../generated/CloneFactory/CloneFactory";
+import { Deployment } from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
 import { newMockEvent, createMockedFunction } from "matchstick-as";
 import {
-    Authorizer,
-    Deployer,
-    OffchainAssetReceiptVault
+  Authorizer,
+  Deployer,
+  OffchainAssetReceiptVault,
 } from "../generated/schema";
 import {
-    BigInt,
-    ethereum,
-    Address,
-    Bytes,
-    Value,
-  } from "@graphprotocol/graph-ts";
-import { OffchainAssetReceiptVaultTemplate, OffchainAssetReceiptVaultAuthorizerV1Template } from "../generated/templates";
-import { ZERO } from "../src/utils";
-import { AuthorizerSet, Certify as CertifyEvent, Deposit, Withdraw, ConfiscateShares as ConfiscateSharesEvent, ConfiscateReceipt as ConfiscateReceiptEvent, OffchainAssetReceiptVaultInitializedV2 } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
+  BigInt,
+  ethereum,
+  Address,
+  Bytes,
+  Value,
+} from "@graphprotocol/graph-ts";
 import {
-    RoleAdminChanged,
-    RoleGranted as RoleGrantedEvent,
-    RoleRevoked as RoleRevokedEvent,
-  } from "../generated/templates/OffchainAssetReceiptVaultAuthorizerV1Template/OffchainAssetReceiptVaultAuthorizerV1";
+  OffchainAssetReceiptVaultTemplate,
+  OffchainAssetReceiptVaultAuthorizerV1Template,
+} from "../generated/templates";
+import { ZERO } from "../src/utils";
+import {
+  AuthorizerSet,
+  Certify as CertifyEvent,
+  Deposit,
+  Withdraw,
+  ConfiscateShares as ConfiscateSharesEvent,
+  ConfiscateReceipt as ConfiscateReceiptEvent,
+  OffchainAssetReceiptVaultInitializedV2,
+  Transfer,
+} from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
+import {
+  RoleAdminChanged,
+  RoleGranted as RoleGrantedEvent,
+  RoleRevoked as RoleRevokedEvent,
+} from "../generated/templates/OffchainAssetReceiptVaultAuthorizerV1Template/OffchainAssetReceiptVaultAuthorizerV1";
 
 export class VaultConfig {
-    address: Address;
-    name: String;
-    symbol: String;
-  
-    constructor(address: Address, name: String, symbol: String) {
-      this.address = address;
-      this.name = name;
-      this.symbol = symbol;
-    }
+  address: Address;
+  name: String;
+  symbol: String;
+
+  constructor(address: Address, name: String, symbol: String) {
+    this.address = address;
+    this.name = name;
+    this.symbol = symbol;
+  }
 }
 
 export class ReceiptVaultConfig {
-    vaultConfig: VaultConfig;
-    receipt: Address;
+  vaultConfig: VaultConfig;
+  receipt: Address;
 
-    constructor(vaultConfig: VaultConfig, receipt: Address) {
-        this.vaultConfig = vaultConfig;
-        this.receipt = receipt;
-    }   
+  constructor(vaultConfig: VaultConfig, receipt: Address) {
+    this.vaultConfig = vaultConfig;
+    this.receipt = receipt;
+  }
 }
 
 export class OffchainAssetReceiptVaultConfigV2 {
-    initialAdmin: Address;
-    receiptVaultConfig: ReceiptVaultConfig;
+  initialAdmin: Address;
+  receiptVaultConfig: ReceiptVaultConfig;
 
-    constructor(initialAdmin: Address, receiptVaultConfig: ReceiptVaultConfig) {
-        this.initialAdmin = initialAdmin;
-        this.receiptVaultConfig = receiptVaultConfig;
-    }
+  constructor(initialAdmin: Address, receiptVaultConfig: ReceiptVaultConfig) {
+    this.initialAdmin = initialAdmin;
+    this.receiptVaultConfig = receiptVaultConfig;
+  }
 }
 
 // event NewClone(address sender, address implementation, address clone);
 export function createNewCloneEvent(
-    sender: Address,
-    implementation: Address,
-    clone: Address
-  ): NewClone {
-
-    let mockEvent = newMockEvent();
-    let newCloneEvent = new NewClone(
-        mockEvent.address,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    newCloneEvent.parameters = new Array();
-    newCloneEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    newCloneEvent.parameters.push(
-        new ethereum.EventParam("implementation", ethereum.Value.fromAddress(implementation))
-    );
-    newCloneEvent.parameters.push(
-        new ethereum.EventParam("clone", ethereum.Value.fromAddress(clone))
-    );
-    return newCloneEvent;
+  sender: Address,
+  implementation: Address,
+  clone: Address,
+): NewClone {
+  let mockEvent = newMockEvent();
+  let newCloneEvent = new NewClone(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  newCloneEvent.parameters = new Array();
+  newCloneEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  newCloneEvent.parameters.push(
+    new ethereum.EventParam(
+      "implementation",
+      ethereum.Value.fromAddress(implementation),
+    ),
+  );
+  newCloneEvent.parameters.push(
+    new ethereum.EventParam("clone", ethereum.Value.fromAddress(clone)),
+  );
+  return newCloneEvent;
 }
 
 // event SetAuthorizer(address sender, address authorizer);
 export function createSetAuthorizerEvent(
-        sender: Address,
-        authorizer: Address,
-        contractAddress: Address
-    ): AuthorizerSet {
-    let mockEvent = newMockEvent();
-    let setAuthorizerEvent = new AuthorizerSet(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    setAuthorizerEvent.parameters = new Array();
-    setAuthorizerEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    setAuthorizerEvent.parameters.push(
-        new ethereum.EventParam("authorizer", ethereum.Value.fromAddress(authorizer))
-    );
-    return setAuthorizerEvent;
+  sender: Address,
+  authorizer: Address,
+  contractAddress: Address,
+): AuthorizerSet {
+  let mockEvent = newMockEvent();
+  let setAuthorizerEvent = new AuthorizerSet(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  setAuthorizerEvent.parameters = new Array();
+  setAuthorizerEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  setAuthorizerEvent.parameters.push(
+    new ethereum.EventParam(
+      "authorizer",
+      ethereum.Value.fromAddress(authorizer),
+    ),
+  );
+  return setAuthorizerEvent;
 }
 
 // event Certify(address sender, uint256 certifyUntil, bool forceUntil, bytes data);
 export function createCertifyEvent(
-    sender: Address,
-    certifyUntil: BigInt,
-    force: boolean,
-    data: Bytes,
-    contractAddress: Address
+  sender: Address,
+  certifyUntil: BigInt,
+  force: boolean,
+  data: Bytes,
+  contractAddress: Address,
 ): CertifyEvent {
-    let mockEvent = newMockEvent();
-    let certifyEvent = new CertifyEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,  
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    certifyEvent.parameters = new Array();
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("certifyUntil", ethereum.Value.fromUnsignedBigInt(certifyUntil))
-    );
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("forceUntil", ethereum.Value.fromBoolean(force))
-    );
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("data", ethereum.Value.fromBytes(data))
-    );
-    return certifyEvent;
+  let mockEvent = newMockEvent();
+  let certifyEvent = new CertifyEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  certifyEvent.parameters = new Array();
+  certifyEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  certifyEvent.parameters.push(
+    new ethereum.EventParam(
+      "certifyUntil",
+      ethereum.Value.fromUnsignedBigInt(certifyUntil),
+    ),
+  );
+  certifyEvent.parameters.push(
+    new ethereum.EventParam("forceUntil", ethereum.Value.fromBoolean(force)),
+  );
+  certifyEvent.parameters.push(
+    new ethereum.EventParam("data", ethereum.Value.fromBytes(data)),
+  );
+  return certifyEvent;
 }
 
 //event Deposit(address sender, address owner, uint256 assets, uint256 shares, uint256 id, bytes receiptInformation);
 export function createDepositEvent(
-    sender: Address,
-    owner: Address,
-    amount: BigInt,
-    shares: BigInt,
-    id: BigInt,
-    receiptInformation: Bytes,
-    contractAddress: Address
+  sender: Address,
+  owner: Address,
+  amount: BigInt,
+  shares: BigInt,
+  id: BigInt,
+  receiptInformation: Bytes,
+  contractAddress: Address,
 ): Deposit {
-    let mockEvent = newMockEvent();
-    let depositEvent = new Deposit(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    depositEvent.parameters = new Array();
-    depositEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("assets", ethereum.Value.fromUnsignedBigInt(amount))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("shares", ethereum.Value.fromUnsignedBigInt(shares))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("receiptInformation", ethereum.Value.fromBytes(receiptInformation))
-    );
-    
-    return depositEvent;
+  let mockEvent = newMockEvent();
+  let depositEvent = new Deposit(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  depositEvent.parameters = new Array();
+  depositEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam(
+      "assets",
+      ethereum.Value.fromUnsignedBigInt(amount),
+    ),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id)),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam(
+      "receiptInformation",
+      ethereum.Value.fromBytes(receiptInformation),
+    ),
+  );
+
+  return depositEvent;
 }
 
 // event Withdraw(address sender, address receiver, address owner, uint256 assets, uint256 shares, uint256 id, bytes receiptInformation);
 export function createWithdrawEvent(
-    sender: Address,
-    receiver: Address,
-    owner: Address,
-    amount: BigInt,
-    shares: BigInt,
-    id: BigInt,
-    receiptInformation: Bytes,
-    contractAddress: Address
+  sender: Address,
+  receiver: Address,
+  owner: Address,
+  amount: BigInt,
+  shares: BigInt,
+  id: BigInt,
+  receiptInformation: Bytes,
+  contractAddress: Address,
 ): Withdraw {
-    let mockEvent = newMockEvent();
-    let withdrawEvent = new Withdraw(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    withdrawEvent.parameters = new Array();
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("assets", ethereum.Value.fromUnsignedBigInt(amount))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("shares", ethereum.Value.fromUnsignedBigInt(shares))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("receiptInformation", ethereum.Value.fromBytes(receiptInformation))
-    );
-    return withdrawEvent;
-    
+  let mockEvent = newMockEvent();
+  let withdrawEvent = new Withdraw(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  withdrawEvent.parameters = new Array();
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam(
+      "assets",
+      ethereum.Value.fromUnsignedBigInt(amount),
+    ),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam(
+      "receiptInformation",
+      ethereum.Value.fromBytes(receiptInformation),
+    ),
+  );
+  return withdrawEvent;
 }
-
 
 //event ConfiscateShares(address sender, address confiscatee, uint256 targetAmount, uint256 confiscated, bytes justification);
 export function createConfiscateSharesEvent(
-    sender: Address,
-    confiscatee: Address,
-    targetAmount: BigInt,
-    confiscated: BigInt,
-    justification: Bytes,
-    contractAddress: Address
+  sender: Address,
+  confiscatee: Address,
+  targetAmount: BigInt,
+  confiscated: BigInt,
+  justification: Bytes,
+  contractAddress: Address,
 ): ConfiscateSharesEvent {
-    let mockEvent = newMockEvent();
-    let confiscateSharesEvent = new ConfiscateSharesEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,  
-        mockEvent.parameters,
-        null
-    );
-    confiscateSharesEvent.parameters = new Array();
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("confiscatee", ethereum.Value.fromAddress(confiscatee))
-    );
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("targetAmount", ethereum.Value.fromUnsignedBigInt(targetAmount))
-    );  
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("confiscated", ethereum.Value.fromUnsignedBigInt(confiscated))
-    );
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("justification", ethereum.Value.fromBytes(justification))
-    );
-    return confiscateSharesEvent;
+  let mockEvent = newMockEvent();
+  let confiscateSharesEvent = new ConfiscateSharesEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  confiscateSharesEvent.parameters = new Array();
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscatee",
+      ethereum.Value.fromAddress(confiscatee),
+    ),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "targetAmount",
+      ethereum.Value.fromUnsignedBigInt(targetAmount),
+    ),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscated",
+      ethereum.Value.fromUnsignedBigInt(confiscated),
+    ),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "justification",
+      ethereum.Value.fromBytes(justification),
+    ),
+  );
+  return confiscateSharesEvent;
 }
 
 //event ConfiscateReceipt(address sender, address confiscatee, uint256 id, uint256 targetAmount, uint256 confiscated, bytes justification);
 export function createConfiscateReceiptEvent(
-    sender: Address,
-    confiscatee: Address,
-    id: BigInt,
-    targetAmount: BigInt,
-    confiscated: BigInt,
-    justification: Bytes,
-    contractAddress: Address
+  sender: Address,
+  confiscatee: Address,
+  id: BigInt,
+  targetAmount: BigInt,
+  confiscated: BigInt,
+  justification: Bytes,
+  contractAddress: Address,
 ): ConfiscateReceiptEvent {
-    let mockEvent = newMockEvent();
-    let confiscateReceiptEvent = new ConfiscateReceiptEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    confiscateReceiptEvent.parameters = new Array();
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("confiscatee", ethereum.Value.fromAddress(confiscatee))
-    );
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id))
-    );  
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("targetAmount", ethereum.Value.fromUnsignedBigInt(targetAmount))
-    );
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("confiscated", ethereum.Value.fromUnsignedBigInt(confiscated))
-    );  
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("justification", ethereum.Value.fromBytes(justification))
-    );
-    return confiscateReceiptEvent;
+  let mockEvent = newMockEvent();
+  let confiscateReceiptEvent = new ConfiscateReceiptEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  confiscateReceiptEvent.parameters = new Array();
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscatee",
+      ethereum.Value.fromAddress(confiscatee),
+    ),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id)),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "targetAmount",
+      ethereum.Value.fromUnsignedBigInt(targetAmount),
+    ),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscated",
+      ethereum.Value.fromUnsignedBigInt(confiscated),
+    ),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "justification",
+      ethereum.Value.fromBytes(justification),
+    ),
+  );
+  return confiscateReceiptEvent;
 }
 
 // event OffchainAssetReceiptVaultInitializedV2(address sender, OffchainAssetReceiptVaultConfigV2 config);
@@ -338,183 +394,255 @@ export function createConfiscateReceiptEvent(
 //     address receipt;
 // }
 export function createOffchainAssetReceiptVaultInitializedV2Event(
-    sender: Address,
-    initialAdmin: Address,
-    receiptVaultConfig: ReceiptVaultConfig,
-    contractAddress: Address
+  sender: Address,
+  initialAdmin: Address,
+  receiptVaultConfig: ReceiptVaultConfig,
+  contractAddress: Address,
 ): OffchainAssetReceiptVaultInitializedV2 {
-    let mockEvent = newMockEvent();
-    let offchainAssetReceiptVaultInitializedV2Event = new OffchainAssetReceiptVaultInitializedV2(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
+  let mockEvent = newMockEvent();
+  let offchainAssetReceiptVaultInitializedV2Event =
+    new OffchainAssetReceiptVaultInitializedV2(
+      contractAddress,
+      mockEvent.logIndex,
+      mockEvent.transactionLogIndex,
+      mockEvent.logType,
+      mockEvent.block,
+      mockEvent.transaction,
+      mockEvent.parameters,
+      null,
     );
-    
-    // Create the ReceiptVaultConfigV2 tuple: (asset, name, symbol, receipt)
-    let receiptVaultConfigValues = new ethereum.Tuple();
-    receiptVaultConfigValues.push(ethereum.Value.fromAddress(receiptVaultConfig.vaultConfig.address)); // asset
-    receiptVaultConfigValues.push(ethereum.Value.fromString(receiptVaultConfig.vaultConfig.name.toString())); // name
-    receiptVaultConfigValues.push(ethereum.Value.fromString(receiptVaultConfig.vaultConfig.symbol.toString())); // symbol
-    receiptVaultConfigValues.push(ethereum.Value.fromAddress(receiptVaultConfig.receipt)); // receipt
-    
-    // Create the OffchainAssetReceiptVaultConfigV2 tuple: (initialAdmin, receiptVaultConfig)
-    let configTuple = new ethereum.Tuple();
-    configTuple.push(ethereum.Value.fromAddress(initialAdmin));
-    configTuple.push(ethereum.Value.fromTuple(receiptVaultConfigValues));
-    
-    offchainAssetReceiptVaultInitializedV2Event.parameters = new Array();
-    offchainAssetReceiptVaultInitializedV2Event.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    offchainAssetReceiptVaultInitializedV2Event.parameters.push(
-        new ethereum.EventParam("config", ethereum.Value.fromTuple(configTuple))
-    );
-    
-    return offchainAssetReceiptVaultInitializedV2Event;
+
+  // Create the ReceiptVaultConfigV2 tuple: (asset, name, symbol, receipt)
+  let receiptVaultConfigValues = new ethereum.Tuple();
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromAddress(receiptVaultConfig.vaultConfig.address),
+  ); // asset
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromString(receiptVaultConfig.vaultConfig.name.toString()),
+  ); // name
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromString(receiptVaultConfig.vaultConfig.symbol.toString()),
+  ); // symbol
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromAddress(receiptVaultConfig.receipt),
+  ); // receipt
+
+  // Create the OffchainAssetReceiptVaultConfigV2 tuple: (initialAdmin, receiptVaultConfig)
+  let configTuple = new ethereum.Tuple();
+  configTuple.push(ethereum.Value.fromAddress(initialAdmin));
+  configTuple.push(ethereum.Value.fromTuple(receiptVaultConfigValues));
+
+  offchainAssetReceiptVaultInitializedV2Event.parameters = new Array();
+  offchainAssetReceiptVaultInitializedV2Event.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  offchainAssetReceiptVaultInitializedV2Event.parameters.push(
+    new ethereum.EventParam("config", ethereum.Value.fromTuple(configTuple)),
+  );
+
+  return offchainAssetReceiptVaultInitializedV2Event;
 }
 //event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
 export function createRoleAdminChangedEvent(
-    role: Bytes,
-    previousAdminRole: Bytes,
-    newAdminRole: Bytes,
-    contractAddress: Address
+  role: Bytes,
+  previousAdminRole: Bytes,
+  newAdminRole: Bytes,
+  contractAddress: Address,
 ): RoleAdminChanged {
-    let mockEvent = newMockEvent();
-    let roleAdminChangedEvent = new RoleAdminChanged(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    roleAdminChangedEvent.parameters = new Array();
-    roleAdminChangedEvent.parameters.push(
-        new ethereum.EventParam("role", ethereum.Value.fromBytes(role))
-    );
-    roleAdminChangedEvent.parameters.push(
-        new ethereum.EventParam("previousAdminRole", ethereum.Value.fromBytes(previousAdminRole))
-    );
-    roleAdminChangedEvent.parameters.push(
-        new ethereum.EventParam("newAdminRole", ethereum.Value.fromBytes(newAdminRole))
-    );
-    return roleAdminChangedEvent;
-}   
+  let mockEvent = newMockEvent();
+  let roleAdminChangedEvent = new RoleAdminChanged(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  roleAdminChangedEvent.parameters = new Array();
+  roleAdminChangedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromBytes(role)),
+  );
+  roleAdminChangedEvent.parameters.push(
+    new ethereum.EventParam(
+      "previousAdminRole",
+      ethereum.Value.fromBytes(previousAdminRole),
+    ),
+  );
+  roleAdminChangedEvent.parameters.push(
+    new ethereum.EventParam(
+      "newAdminRole",
+      ethereum.Value.fromBytes(newAdminRole),
+    ),
+  );
+  return roleAdminChangedEvent;
+}
 
 // event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
 export function createRoleGrantedEvent(
-    role: Bytes,
-    account: Address,
-    sender: Address,    
-    contractAddress: Address
+  role: Bytes,
+  account: Address,
+  sender: Address,
+  contractAddress: Address,
 ): RoleGrantedEvent {
-    let mockEvent = newMockEvent();
-    let roleGrantedEvent = new RoleGrantedEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );  
-    roleGrantedEvent.parameters = new Array();
-    roleGrantedEvent.parameters.push(
-        new ethereum.EventParam("role", ethereum.Value.fromBytes(role))
-    );  
-    roleGrantedEvent.parameters.push(
-        new ethereum.EventParam("account", ethereum.Value.fromAddress(account))
-    );  
-    roleGrantedEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );  
-    return roleGrantedEvent;
+  let mockEvent = newMockEvent();
+  let roleGrantedEvent = new RoleGrantedEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  roleGrantedEvent.parameters = new Array();
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromBytes(role)),
+  );
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(account)),
+  );
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  return roleGrantedEvent;
 }
 
 //event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
 export function createRoleRevokedEvent(
-    role: Bytes,
-    account: Address,
-    sender: Address,
-    contractAddress: Address
+  role: Bytes,
+  account: Address,
+  sender: Address,
+  contractAddress: Address,
 ): RoleRevokedEvent {
-    let mockEvent = newMockEvent();
-    let roleRevokedEvent = new RoleRevokedEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,  
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );  
-    roleRevokedEvent.parameters = new Array();
-    roleRevokedEvent.parameters.push(
-        new ethereum.EventParam("role", ethereum.Value.fromBytes(role))
-    );  
-    roleRevokedEvent.parameters.push(
-        new ethereum.EventParam("account", ethereum.Value.fromAddress(account))
-    );  
-    roleRevokedEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );  
-    return roleRevokedEvent;
+  let mockEvent = newMockEvent();
+  let roleRevokedEvent = new RoleRevokedEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  roleRevokedEvent.parameters = new Array();
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromBytes(role)),
+  );
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(account)),
+  );
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  return roleRevokedEvent;
 }
 
 // event Deployment(address sender, address asset, address wrapper);
 export function createDeploymentEvent(
-    sender: Address,
-    asset: Address,
-    wrapper: Address,
-    contractAddress: Address
+  sender: Address,
+  asset: Address,
+  wrapper: Address,
+  contractAddress: Address,
 ): Deployment {
-    let mockEvent = newMockEvent();
-    let deploymentEvent = new Deployment(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    deploymentEvent.parameters = new Array();
-    deploymentEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    deploymentEvent.parameters.push(
-        new ethereum.EventParam("asset", ethereum.Value.fromAddress(asset))
-    );
-    deploymentEvent.parameters.push(
-        new ethereum.EventParam("wrapper", ethereum.Value.fromAddress(wrapper))
-    );
-    return deploymentEvent;
+  let mockEvent = newMockEvent();
+  let deploymentEvent = new Deployment(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  deploymentEvent.parameters = new Array();
+  deploymentEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  deploymentEvent.parameters.push(
+    new ethereum.EventParam("asset", ethereum.Value.fromAddress(asset)),
+  );
+  deploymentEvent.parameters.push(
+    new ethereum.EventParam("wrapper", ethereum.Value.fromAddress(wrapper)),
+  );
+  return deploymentEvent;
 }
 
 export function createMockERC20Functions(address: Address): void {
-    createMockedFunction(address, "name", "name():(string)")
-      .withArgs([])
-      .returns([ethereum.Value.fromString("Test")]);
-    createMockedFunction(address, "symbol", "symbol():(string)")
-      .withArgs([])
-      .returns([ethereum.Value.fromString("TST")]);
-    createMockedFunction(address, "decimals", "decimals():(uint8)")
-      .withArgs([])
-      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(18))]);
-  }
+  createMockedFunction(address, "name", "name():(string)")
+    .withArgs([])
+    .returns([ethereum.Value.fromString("Test")]);
+  createMockedFunction(address, "symbol", "symbol():(string)")
+    .withArgs([])
+    .returns([ethereum.Value.fromString("TST")]);
+  createMockedFunction(address, "decimals", "decimals():(uint8)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(18))]);
+}
 
-export function createMockReceiptFunction(vaultAddress: Address, receiptAddress: Address): void {
-    createMockedFunction(vaultAddress, "receipt", "receipt():(address)")
-      .withArgs([])
-      .returns([ethereum.Value.fromAddress(receiptAddress)]);
-  }
+export function createMockReceiptFunction(
+  vaultAddress: Address,
+  receiptAddress: Address,
+): void {
+  createMockedFunction(vaultAddress, "receipt", "receipt():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(receiptAddress)]);
+}
+
+// event Transfer(address indexed from, address indexed to, uint256 value);
+export function createTransferEvent(
+  from: Address,
+  to: Address,
+  value: BigInt,
+  contractAddress: Address,
+): Transfer {
+  let mockEvent = newMockEvent();
+  let transferEvent = new Transfer(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  transferEvent.parameters = new Array();
+  transferEvent.parameters.push(
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from)),
+  );
+  transferEvent.parameters.push(
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to)),
+  );
+  transferEvent.parameters.push(
+    new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value)),
+  );
+  return transferEvent;
+}
+
+export function createMockBalanceOfFunction(
+  vaultAddress: Address,
+  holder: Address,
+  balance: BigInt,
+): void {
+  createMockedFunction(
+    vaultAddress,
+    "balanceOf",
+    "balanceOf(address):(uint256)",
+  )
+    .withArgs([ethereum.Value.fromAddress(holder)])
+    .returns([ethereum.Value.fromUnsignedBigInt(balance)]);
+}
+
+export function createMockTotalSupplyFunction(
+  vaultAddress: Address,
+  totalSupply: BigInt,
+): void {
+  createMockedFunction(vaultAddress, "totalSupply", "totalSupply():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(totalSupply)]);
+}


### PR DESCRIPTION
## Summary
- switch wrapped token template ABI to ERC4626 and add a minimal ABI with `convertToAssets`/`convertToShares`
- store canonical `assetsPerShare` and `sharesPerAsset` (for 1e18 units) on `OffchainAssetReceiptVault`
- keep `WrappedTokenTransfer` focused on transfer event payload and update vault exchange-rate block/timestamp on wrapped transfers

## Test plan
- [x] `npx graph codegen`
- [x] `npx graph build`

Made with [Cursor](https://cursor.com)