### PR TITLE
Materialize vault token aggregates for REST token details

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -79,6 +79,14 @@ type OffchainAssetReceiptVault @entity {
   hashCount: BigInt!
   "Token holders"
   tokenHolders: [TokenHolder!] @derivedFrom(field: "offchainAssetReceiptVault")
+  "Count of TokenHolder entities with balance > 0"
+  tokenHolderCount: BigInt!
+  "Count of SharesTransfer entities for this vault"
+  shareTransferCount: BigInt!
+  "Sum of DepositWithReceipt.amount for this vault"
+  depositVolume: BigInt!
+  "Sum of WithdrawWithReceipt.amount for this vault"
+  withdrawVolume: BigInt!
   "Wrapped ERC20 token transfers for this vault (wallet-to-wallet)"
   wrappedTokenTransfers: [WrappedTokenTransfer!]
     @derivedFrom(field: "offchainAssetReceiptVault")

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -298,6 +298,10 @@ export function handleDeposit(event: Deposit): void {
     receiptBalance.save();
     depositWithReceipt.save();
 
+    offchainAssetReceiptVault.depositVolume =
+      offchainAssetReceiptVault.depositVolume.plus(event.params.shares);
+    offchainAssetReceiptVault.save();
+
     let account = getAccount(
       event.params.owner.toHex(),
       offchainAssetReceiptVault.id,
@@ -450,6 +454,7 @@ function upsertTokenHolder(
 ): BigInt {
   const id = holderId(vaultAddr, user);
   let th = TokenHolder.load(id);
+  const previousBalance = th != null ? th.balance : ZERO;
   if (th == null) {
     th = new TokenHolder(id);
     th.offchainAssetReceiptVault = vault.id;
@@ -459,6 +464,13 @@ function upsertTokenHolder(
   const bal = vaultContract.balanceOf(user);
   th.balance = bal;
   th.save();
+
+  if (previousBalance.equals(ZERO) && bal.gt(ZERO)) {
+    vault.tokenHolderCount = vault.tokenHolderCount.plus(ONE);
+  } else if (previousBalance.gt(ZERO) && bal.equals(ZERO)) {
+    vault.tokenHolderCount = vault.tokenHolderCount.minus(ONE);
+  }
+
   return bal;
 }
 
@@ -551,6 +563,7 @@ export function handleTransfer(event: Transfer): void {
   st.value = toDecimals(event.params.value, 18);
 
   st.save();
+  vault.shareTransferCount = vault.shareTransferCount.plus(ONE);
   vault.save();
 }
 
@@ -612,5 +625,9 @@ export function handleWithdraw(event: Withdraw): void {
     }
 
     withdrawWithReceipt.save();
+
+    offchainAssetReceiptVault.withdrawVolume =
+      offchainAssetReceiptVault.withdrawVolume.plus(event.params.shares);
+    offchainAssetReceiptVault.save();
   }
 }

--- a/src/StoxUnifiedDeployer.ts
+++ b/src/StoxUnifiedDeployer.ts
@@ -1,63 +1,66 @@
+import { Deployment } from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
 import {
-    Deployment,
-  } from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
-  import {
-    Authorizer,
-    Deployer,
-    OffchainAssetReceiptVault
-  } from "../generated/schema";
-  import { OffchainAssetReceiptVaultTemplate, WrappedTokenTemplate } from "../generated/templates";
-  import { OffchainAssetReceiptVault as OffchainAssetReceiptVaultContract } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
-  import { ZERO, ZERO_ADDRESS } from "./utils";
-  import { Address, DataSourceContext } from "@graphprotocol/graph-ts";
+  Authorizer,
+  Deployer,
+  OffchainAssetReceiptVault,
+} from "../generated/schema";
+import {
+  OffchainAssetReceiptVaultTemplate,
+  WrappedTokenTemplate,
+} from "../generated/templates";
+import { OffchainAssetReceiptVault as OffchainAssetReceiptVaultContract } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
+import { ZERO, ZERO_ADDRESS } from "./utils";
+import { Address, DataSourceContext } from "@graphprotocol/graph-ts";
 
+export function handleDeployment(event: Deployment): void {
+  let child = new OffchainAssetReceiptVault(event.params.asset.toHex());
+  child.address = event.params.asset;
+  child.wrappedTokenContractAddress = event.params.wrapper;
+  child.deployBlock = event.block.number;
+  child.deployTimestamp = event.block.timestamp;
+  child.deployer = event.params.sender;
+  child.admin = event.params.sender;
 
-  export function handleDeployment(event: Deployment): void { 
+  child.name = "";
+  child.symbol = "";
+  child.totalShares = ZERO;
+  child.certifiedUntil = ZERO;
+  child.hashCount = ZERO;
+  child.shareHoldersCount = ZERO;
+  child.tokenHolderCount = ZERO;
+  child.shareTransferCount = ZERO;
+  child.depositVolume = ZERO;
+  child.withdrawVolume = ZERO;
+  child.activeAuthorizer = ZERO_ADDRESS;
 
-    let child = new OffchainAssetReceiptVault(event.params.asset.toHex());
-    child.address = event.params.asset;
-    child.wrappedTokenContractAddress = event.params.wrapper;
-    child.deployBlock = event.block.number;
-    child.deployTimestamp = event.block.timestamp;
-    child.deployer = event.params.sender;
-    child.admin = event.params.sender;
-  
-    child.name = "";
-    child.symbol = "";
-    child.totalShares = ZERO;
-    child.certifiedUntil = ZERO;
-    child.hashCount = ZERO;
-    child.shareHoldersCount = ZERO;
-    child.activeAuthorizer = ZERO_ADDRESS;
+  // Call receipt() on the asset contract to get the receipt contract address
+  let contract = OffchainAssetReceiptVaultContract.bind(event.params.asset);
+  let receiptResult = contract.try_receipt();
+  if (!receiptResult.reverted) {
+    child.receiptContractAddress = receiptResult.value;
+  }
 
-    // Call receipt() on the asset contract to get the receipt contract address
-    let contract = OffchainAssetReceiptVaultContract.bind(event.params.asset);
-    let receiptResult = contract.try_receipt();
-    if (!receiptResult.reverted) {
-      child.receiptContractAddress = receiptResult.value;
-    }
+  let authorizer = new Authorizer(event.params.asset.toHex());
+  authorizer.address = event.params.asset;
+  authorizer.isActive = true;
+  authorizer.save();
+  child.activeAuthorizer = authorizer.id;
 
-    let authorizer = new Authorizer(event.params.asset.toHex());
-    authorizer.address = event.params.asset;
-    authorizer.isActive = true;
-    authorizer.save();
-    child.activeAuthorizer = authorizer.id;
-    
-    child.save();
-  
-    let deployer = Deployer.load(event.params.sender.toHex());
-    if(!deployer){
-      deployer = new Deployer(event.params.sender.toHex());
-      deployer.hashCount = ZERO;
-      deployer.save();
-    }
-  
-    OffchainAssetReceiptVaultTemplate.create(event.params.asset);
+  child.save();
 
-    let zeroAddr = Address.fromString(ZERO_ADDRESS);
-    if (!event.params.wrapper.equals(zeroAddr)) {
-      let context = new DataSourceContext();
-      context.setString("vaultId", event.params.asset.toHex());
-      WrappedTokenTemplate.createWithContext(event.params.wrapper, context);
-    }
+  let deployer = Deployer.load(event.params.sender.toHex());
+  if (!deployer) {
+    deployer = new Deployer(event.params.sender.toHex());
+    deployer.hashCount = ZERO;
+    deployer.save();
+  }
+
+  OffchainAssetReceiptVaultTemplate.create(event.params.asset);
+
+  let zeroAddr = Address.fromString(ZERO_ADDRESS);
+  if (!event.params.wrapper.equals(zeroAddr)) {
+    let context = new DataSourceContext();
+    context.setString("vaultId", event.params.asset.toHex());
+    WrappedTokenTemplate.createWithContext(event.params.wrapper, context);
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,10 @@ export function getAccount(
       tempVault.totalShares = ZERO;
       tempVault.shareHoldersCount = ZERO;
       tempVault.hashCount = ZERO;
+      tempVault.tokenHolderCount = ZERO;
+      tempVault.shareTransferCount = ZERO;
+      tempVault.depositVolume = ZERO;
+      tempVault.withdrawVolume = ZERO;
       tempVault.certifiedUntil = ZERO;
       tempVault.save();
 

--- a/tests/handleDeployment.test.ts
+++ b/tests/handleDeployment.test.ts
@@ -6,24 +6,19 @@ import {
   afterEach,
   beforeAll,
   clearInBlockStore,
-  dataSourceMock
+  dataSourceMock,
 } from "matchstick-as";
-import {
-  Address,
-  DataSourceContext,
-  Value
-} from "@graphprotocol/graph-ts";
+import { Address, DataSourceContext, Value } from "@graphprotocol/graph-ts";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
 
 describe("Handle Deployment Test", () => {
-
-  const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
 
   beforeAll(() => {
-    let context = new DataSourceContext()
-    context.set('contextVal', Value.fromI32(325))
-    dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
   });
 
   afterEach(() => {
@@ -32,19 +27,27 @@ describe("Handle Deployment Test", () => {
   });
 
   test("handle deployment creates OffchainAssetReceiptVault and Authorizer", () => {
-    const sender = Address.fromString("0x1234567890123456789012345678901234567890");
-    const asset = Address.fromString("0x1234567890123456789012345678901234567891");
-    const receipt = Address.fromString("0x1234567890123456789012345678901234567892");
-    const wrapper = Address.fromString("0x1234567890123456789012345678901234567893");
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const asset = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
+    const receipt = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
+    const wrapper = Address.fromString(
+      "0x1234567890123456789012345678901234567893",
+    );
     const contractAddress = Address.fromString(dataSourceAddress);
-    
+
     // Mock the receipt() RPC call
     createMockReceiptFunction(asset, receipt);
     let deploymentEvent = createDeploymentEvent(
       sender,
       asset,
       wrapper,
-      contractAddress
+      contractAddress,
     );
 
     handleDeployment(deploymentEvent);
@@ -59,77 +62,105 @@ describe("Handle Deployment Test", () => {
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "address",
-      asset.toHexString()
+      asset.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "deployer",
-      sender.toHexString()
+      sender.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "admin",
-      sender.toHexString()
+      sender.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "name",
-      ""
+      "",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "symbol",
-      ""
+      "",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "totalShares",
-      "0"
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "certifiedUntil",
-      "0"
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "hashCount",
-      "0"
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "shareHoldersCount",
-      "0"
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "tokenHolderCount",
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "shareTransferCount",
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "depositVolume",
+      "0",
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      asset.toHexString(),
+      "withdrawVolume",
+      "0",
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "deployBlock",
-      deploymentEvent.block.number.toString()
+      deploymentEvent.block.number.toString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "deployTimestamp",
-      deploymentEvent.block.timestamp.toString()
+      deploymentEvent.block.timestamp.toString(),
     );
 
     // Verify Authorizer entity was created
@@ -137,50 +168,54 @@ describe("Handle Deployment Test", () => {
       "Authorizer",
       asset.toHexString(),
       "address",
-      asset.toHexString()
+      asset.toHexString(),
     );
 
-    assert.fieldEquals(
-      "Authorizer",
-      asset.toHexString(),
-      "isActive",
-      "true"
-    );
+    assert.fieldEquals("Authorizer", asset.toHexString(), "isActive", "true");
 
     // Verify activeAuthorizer is set correctly
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset.toHexString(),
       "activeAuthorizer",
-      asset.toHexString()
+      asset.toHexString(),
     );
 
     // Verify Deployer entity was created
-    assert.fieldEquals(
-      "Deployer",
-      sender.toHexString(),
-      "hashCount",
-      "0"
-    );
+    assert.fieldEquals("Deployer", sender.toHexString(), "hashCount", "0");
   });
 
   test("handle deployment with existing deployer does not create duplicate", () => {
-    const sender = Address.fromString("0x1234567890123456789012345678901234567890");
-    const asset1 = Address.fromString("0x1234567890123456789012345678901234567891");
-    const receipt1 = Address.fromString("0x1234567890123456789012345678901234567892");
-    const wrapper1 = Address.fromString("0x1234567890123456789012345678901234567893");
-    const asset2 = Address.fromString("0x1234567890123456789012345678901234567894");
-    const receipt2 = Address.fromString("0x1234567890123456789012345678901234567895");
-    const wrapper2 = Address.fromString("0x1234567890123456789012345678901234567896");
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const asset1 = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
+    const receipt1 = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
+    const wrapper1 = Address.fromString(
+      "0x1234567890123456789012345678901234567893",
+    );
+    const asset2 = Address.fromString(
+      "0x1234567890123456789012345678901234567894",
+    );
+    const receipt2 = Address.fromString(
+      "0x1234567890123456789012345678901234567895",
+    );
+    const wrapper2 = Address.fromString(
+      "0x1234567890123456789012345678901234567896",
+    );
     const contractAddress = Address.fromString(dataSourceAddress);
-    
+
     // First deployment
     createMockReceiptFunction(asset1, receipt1);
     let deploymentEvent1 = createDeploymentEvent(
       sender,
       asset1,
       wrapper1,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent1);
 
@@ -190,7 +225,7 @@ describe("Handle Deployment Test", () => {
       sender,
       asset2,
       wrapper2,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent2);
 
@@ -204,35 +239,51 @@ describe("Handle Deployment Test", () => {
       "OffchainAssetReceiptVault",
       asset1.toHexString(),
       "deployer",
-      sender.toHexString()
+      sender.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset2.toHexString(),
       "deployer",
-      sender.toHexString()
+      sender.toHexString(),
     );
   });
 
   test("handle deployment with different senders creates separate deployers", () => {
-    const sender1 = Address.fromString("0x1234567890123456789012345678901234567890");
-    const sender2 = Address.fromString("0x1234567890123456789012345678901234567899");
-    const asset1 = Address.fromString("0x1234567890123456789012345678901234567891");
-    const receipt1 = Address.fromString("0x1234567890123456789012345678901234567892");
-    const wrapper1 = Address.fromString("0x1234567890123456789012345678901234567893");
-    const asset2 = Address.fromString("0x1234567890123456789012345678901234567894");
-    const receipt2 = Address.fromString("0x1234567890123456789012345678901234567895");
-    const wrapper2 = Address.fromString("0x1234567890123456789012345678901234567896");
+    const sender1 = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const sender2 = Address.fromString(
+      "0x1234567890123456789012345678901234567899",
+    );
+    const asset1 = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
+    const receipt1 = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
+    const wrapper1 = Address.fromString(
+      "0x1234567890123456789012345678901234567893",
+    );
+    const asset2 = Address.fromString(
+      "0x1234567890123456789012345678901234567894",
+    );
+    const receipt2 = Address.fromString(
+      "0x1234567890123456789012345678901234567895",
+    );
+    const wrapper2 = Address.fromString(
+      "0x1234567890123456789012345678901234567896",
+    );
     const contractAddress = Address.fromString(dataSourceAddress);
-    
+
     // First deployment by sender1
     createMockReceiptFunction(asset1, receipt1);
     let deploymentEvent1 = createDeploymentEvent(
       sender1,
       asset1,
       wrapper1,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent1);
 
@@ -242,7 +293,7 @@ describe("Handle Deployment Test", () => {
       sender2,
       asset2,
       wrapper2,
-      contractAddress
+      contractAddress,
     );
     handleDeployment(deploymentEvent2);
 
@@ -256,14 +307,14 @@ describe("Handle Deployment Test", () => {
       "OffchainAssetReceiptVault",
       asset1.toHexString(),
       "deployer",
-      sender1.toHexString()
+      sender1.toHexString(),
     );
 
     assert.fieldEquals(
       "OffchainAssetReceiptVault",
       asset2.toHexString(),
       "deployer",
-      sender2.toHexString()
+      sender2.toHexString(),
     );
   });
 });

--- a/tests/handleDeposit.test.ts
+++ b/tests/handleDeposit.test.ts
@@ -1,21 +1,27 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock,
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
 } from "matchstick-as";
 import {
-    Address,
-    Bytes,
-    DataSourceContext,
-    Value,
-    BigInt
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
 } from "@graphprotocol/graph-ts";
-import { createDepositEvent, createNewCloneEvent, createMockERC20Functions, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+import {
+  createDepositEvent,
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
@@ -23,136 +29,172 @@ import { handleDeposit } from "../src/OffchainAssetReceiptVault";
 import { getAccount, getReceipt } from "../src/utils";
 
 describe("Deposit Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  test("handle deposit", () => {
+    const depositor = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
 
-    test("handle deposit", () => {
-        const depositor = Address.fromString("0x1234567890123456789012345678901234567890");
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      depositor,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(depositor, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      depositor,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent = createNewCloneEvent(depositor, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    createMockERC20Functions(assetVaultClone);
 
-        createMockERC20Functions(assetVaultClone);
+    const depositEvent = createDepositEvent(
+      depositor,
+      depositor,
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleDeposit(depositEvent);
 
-        const depositEvent = createDepositEvent(
-            depositor,
-            depositor,
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleDeposit(depositEvent);
+    assert.entityCount("DepositWithReceipt", 1);
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
 
-        assert.entityCount("DepositWithReceipt", 1);
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
+    const depositWithReceiptId = `DepositWithReceipt-${depositEvent.transaction.hash.toHex()}-${depositEvent.params.id.toString()}`;
+    const emitter = getAccount(depositor.toHex(), assetVaultClone.toHex()).id;
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "id",
+      depositWithReceiptId,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "timestamp",
+      depositEvent.block.timestamp.toString(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "transaction",
+      depositEvent.transaction.hash.toHex(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "emitter",
+      emitter,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "receiver",
+      emitter,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "caller",
+      emitter,
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "amount",
+      depositEvent.params.shares.toString(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "data",
+      depositEvent.params.receiptInformation.toString(),
+    );
+    assert.fieldEquals(
+      "DepositWithReceipt",
+      depositWithReceiptId,
+      "erc1155TokenId",
+      depositEvent.params.id.toString(),
+    );
 
-        const depositWithReceiptId = `DepositWithReceipt-${depositEvent.transaction.hash.toHex()}-${depositEvent.params.id.toString()}`;
-        const emitter = getAccount(depositor.toHex(), assetVaultClone.toHex()).id;
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "id",
-            depositWithReceiptId
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "timestamp",
-            depositEvent.block.timestamp.toString()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "transaction",
-            depositEvent.transaction.hash.toHex()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "emitter",
-            emitter
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "receiver",
-            emitter
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "caller",
-            emitter
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "amount",
-            depositEvent.params.shares.toString()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "data",
-            depositEvent.params.receiptInformation.toString()
-        );
-        assert.fieldEquals(
-            "DepositWithReceipt",
-            depositWithReceiptId,
-            "erc1155TokenId",
-            depositEvent.params.id.toString()
-        );
+    const currentReceipt = getReceipt(
+      assetVaultClone.toHex(),
+      depositEvent.params.id,
+    );
+    assert.fieldEquals(
+      "Receipt",
+      currentReceipt.id,
+      "receiptId",
+      depositEvent.params.id.toString(),
+    );
+    assert.fieldEquals(
+      "Receipt",
+      currentReceipt.id,
+      "shares",
+      depositEvent.params.shares.toString(),
+    );
+    assert.fieldEquals(
+      "Receipt",
+      currentReceipt.id,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
 
-        const currentReceipt = getReceipt(assetVaultClone.toHex(), depositEvent.params.id);
-        assert.fieldEquals(
-            "Receipt",
-            currentReceipt.id,
-            "receiptId",
-            depositEvent.params.id.toString()
-        );
-        assert.fieldEquals(
-            "Receipt",
-            currentReceipt.id,
-            "shares",
-            depositEvent.params.shares.toString()
-        );
-        assert.fieldEquals(
-            "Receipt",
-            currentReceipt.id,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );  
-    })
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "depositVolume",
+      depositEvent.params.shares.toString(),
+    );
 
-})
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "withdrawVolume",
+      "0",
+    );
+  });
+});

--- a/tests/handleTransfer.test.ts
+++ b/tests/handleTransfer.test.ts
@@ -1,0 +1,175 @@
+import {
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
+} from "matchstick-as";
+import {
+  Address,
+  DataSourceContext,
+  Value,
+  BigInt,
+} from "@graphprotocol/graph-ts";
+import {
+  createDeploymentEvent,
+  createMockERC20Functions,
+  createMockReceiptFunction,
+  createTransferEvent,
+  createMockBalanceOfFunction,
+  createMockTotalSupplyFunction,
+} from "./mock.test";
+import { handleDeployment } from "../src/StoxUnifiedDeployer";
+import { handleTransfer } from "../src/OffchainAssetReceiptVault";
+import { ZERO, ZERO_ADDRESS } from "../src/utils";
+
+describe("Transfer Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
+
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
+
+  test("handle transfer updates share transfer count and token holder count", () => {
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const sender = Address.fromString(
+      "0x0000000000000000000000000000000000eeeeee",
+    );
+    const recipient = Address.fromString(
+      "0x0000000000000000000000000000000000ffffff",
+    );
+    const zero = Address.fromString(ZERO_ADDRESS);
+
+    createMockReceiptFunction(assetVaultClone, receipt);
+    handleDeployment(
+      createDeploymentEvent(
+        deployer,
+        assetVaultClone,
+        wrapper,
+        Address.fromString(dataSourceAddress),
+      ),
+    );
+    createMockERC20Functions(assetVaultClone);
+
+    const transferAmount = BigInt.fromString("1000000000000000000");
+    const senderBalanceAfter = BigInt.fromString("500000000000000000");
+    const recipientBalanceAfter = transferAmount;
+
+    createMockTotalSupplyFunction(assetVaultClone, transferAmount);
+    createMockBalanceOfFunction(assetVaultClone, sender, senderBalanceAfter);
+    createMockBalanceOfFunction(
+      assetVaultClone,
+      recipient,
+      recipientBalanceAfter,
+    );
+
+    handleTransfer(
+      createTransferEvent(sender, recipient, transferAmount, assetVaultClone),
+    );
+
+    assert.entityCount("SharesTransfer", 1);
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "1",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "2",
+    );
+
+    createMockBalanceOfFunction(assetVaultClone, sender, ZERO);
+    createMockTotalSupplyFunction(assetVaultClone, recipientBalanceAfter);
+
+    handleTransfer(
+      createTransferEvent(
+        sender,
+        recipient,
+        senderBalanceAfter,
+        assetVaultClone,
+      ),
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "2",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "1",
+    );
+
+    createMockBalanceOfFunction(assetVaultClone, recipient, ZERO);
+    createMockTotalSupplyFunction(assetVaultClone, ZERO);
+
+    handleTransfer(
+      createTransferEvent(
+        recipient,
+        zero,
+        recipientBalanceAfter,
+        assetVaultClone,
+      ),
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "3",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "0",
+    );
+
+    createMockBalanceOfFunction(assetVaultClone, recipient, transferAmount);
+    createMockTotalSupplyFunction(assetVaultClone, transferAmount);
+
+    handleTransfer(
+      createTransferEvent(zero, recipient, transferAmount, assetVaultClone),
+    );
+
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "shareTransferCount",
+      "4",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "tokenHolderCount",
+      "1",
+    );
+  });
+});

--- a/tests/handleWithdraw.test.ts
+++ b/tests/handleWithdraw.test.ts
@@ -1,188 +1,221 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
 } from "matchstick-as";
 import {
-    Address,
-    Bytes,
-    DataSourceContext,
-    Value,
-    BigInt
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
 } from "@graphprotocol/graph-ts";
-import { createDepositEvent, createNewCloneEvent, createMockERC20Functions, createWithdrawEvent, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+import {
+  createDepositEvent,
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createWithdrawEvent,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
-import { handleDeposit, handleWithdraw } from "../src/OffchainAssetReceiptVault";
+import {
+  handleDeposit,
+  handleWithdraw,
+} from "../src/OffchainAssetReceiptVault";
 import { getAccount, getReceiptBalance } from "../src/utils";
 
-
 describe("Withdraw Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  test("handle withdraw", () => {
+    const depositorWithdrawer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
 
-    test("handle withdraw", () => {
-        const depositorWithdrawer = Address.fromString("0x1234567890123456789012345678901234567890");
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      depositorWithdrawer,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(depositorWithdrawer, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      depositorWithdrawer,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent = createNewCloneEvent(depositorWithdrawer, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    createMockERC20Functions(assetVaultClone);
 
-        createMockERC20Functions(assetVaultClone);
+    const depositEvent = createDepositEvent(
+      depositorWithdrawer,
+      depositorWithdrawer,
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleDeposit(depositEvent);
 
-        const depositEvent = createDepositEvent(
-            depositorWithdrawer,
-            depositorWithdrawer,
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleDeposit(depositEvent);
+    assert.entityCount("DepositWithReceipt", 1);
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
 
-        assert.entityCount("DepositWithReceipt", 1);
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 2); // 1 from vault deployment + 1 from authorizer clone
+    const withdrawEvent = createWithdrawEvent(
+      depositorWithdrawer,
+      depositorWithdrawer,
+      depositorWithdrawer,
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleWithdraw(withdrawEvent);
+    assert.entityCount("WithdrawWithReceipt", 1);
 
-        const withdrawEvent = createWithdrawEvent(
-            depositorWithdrawer,
-            depositorWithdrawer,
-            depositorWithdrawer,
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleWithdraw(withdrawEvent);
-        assert.entityCount("WithdrawWithReceipt", 1);
+    const withdrawWithReceiptId = `WithdrawWithReceipt-${withdrawEvent.transaction.hash.toHex()}-${withdrawEvent.params.id.toString()}`;
+    const emitter = getAccount(
+      depositorWithdrawer.toHex(),
+      assetVaultClone.toHex(),
+    ).id;
 
-        const withdrawWithReceiptId = `WithdrawWithReceipt-${withdrawEvent.transaction.hash.toHex()}-${withdrawEvent.params.id.toString()}`;
-        const emitter = getAccount(depositorWithdrawer.toHex(), assetVaultClone.toHex()).id;
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "id",
+      withdrawWithReceiptId,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "id",
-            withdrawWithReceiptId
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "amount",
+      withdrawEvent.params.shares.toString(),
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "amount",
-            withdrawEvent.params.shares.toString()
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "caller",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "caller",
-            emitter
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "emitter",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "emitter",
-            emitter
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "owner",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "owner",
-            emitter
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "data",
+      withdrawEvent.params.receiptInformation.toString(),
+    );
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "data",
-            withdrawEvent.params.receiptInformation.toString()
-        );
+    assert.fieldEquals(
+      "WithdrawWithReceipt",
+      withdrawWithReceiptId,
+      "erc1155TokenId",
+      withdrawEvent.params.id.toString(),
+    );
+    const receiptBalance = getReceiptBalance(
+      assetVaultClone.toHex(),
+      withdrawEvent.params.id,
+    );
+    assert.fieldEquals("ReceiptBalance", receiptBalance.id, "value", "0.5");
+    assert.fieldEquals(
+      "ReceiptBalance",
+      receiptBalance.id,
+      "valueExact",
+      "500000000000000000",
+    );
+    const withdrawEvent2 = createWithdrawEvent(
+      depositorWithdrawer,
+      depositorWithdrawer,
+      depositorWithdrawer,
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("500000000000000000"),
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    handleWithdraw(withdrawEvent2);
 
-        assert.fieldEquals(
-            "WithdrawWithReceipt",
-            withdrawWithReceiptId,
-            "erc1155TokenId",
-            withdrawEvent.params.id.toString()
-        );
-        const receiptBalance = getReceiptBalance(assetVaultClone.toHex(), withdrawEvent.params.id);
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "value",
-            "0.5"
-        );
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "valueExact",
-            "500000000000000000"
-        );
-        const withdrawEvent2 = createWithdrawEvent(
-            depositorWithdrawer,
-            depositorWithdrawer,
-            depositorWithdrawer,
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("500000000000000000"),
-            BigInt.fromString("1"),
-            Bytes.fromHexString("0x"),
-            assetVaultClone
-        );
-        handleWithdraw(withdrawEvent2);
+    assert.entityCount("WithdrawWithReceipt", 1);
 
-        assert.entityCount("WithdrawWithReceipt", 1);
+    assert.fieldEquals("ReceiptBalance", receiptBalance.id, "value", "0");
 
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "value",
-            "0"
-        );
+    assert.fieldEquals("ReceiptBalance", receiptBalance.id, "valueExact", "0");
 
-        assert.fieldEquals(
-            "ReceiptBalance",
-            receiptBalance.id,
-            "valueExact",
-            "0"
-        );
-    })
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "depositVolume",
+      depositEvent.params.shares.toString(),
+    );
 
-})
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+      "withdrawVolume",
+      "1000000000000000000",
+    );
+  });
+});

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -1,329 +1,385 @@
-import {
-    NewClone,
-} from "../generated/CloneFactory/CloneFactory";
-import {
-    Deployment,
-} from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
+import { NewClone } from "../generated/CloneFactory/CloneFactory";
+import { Deployment } from "../generated/StoxUnifiedDeployer/StoxUnifiedDeployer";
 import { newMockEvent, createMockedFunction } from "matchstick-as";
 import {
-    Authorizer,
-    Deployer,
-    OffchainAssetReceiptVault
+  Authorizer,
+  Deployer,
+  OffchainAssetReceiptVault,
 } from "../generated/schema";
 import {
-    BigInt,
-    ethereum,
-    Address,
-    Bytes,
-    Value,
-  } from "@graphprotocol/graph-ts";
-import { OffchainAssetReceiptVaultTemplate, OffchainAssetReceiptVaultAuthorizerV1Template } from "../generated/templates";
-import { ZERO } from "../src/utils";
-import { AuthorizerSet, Certify as CertifyEvent, Deposit, Withdraw, ConfiscateShares as ConfiscateSharesEvent, ConfiscateReceipt as ConfiscateReceiptEvent, OffchainAssetReceiptVaultInitializedV2 } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
+  BigInt,
+  ethereum,
+  Address,
+  Bytes,
+  Value,
+} from "@graphprotocol/graph-ts";
 import {
-    RoleAdminChanged,
-    RoleGranted as RoleGrantedEvent,
-    RoleRevoked as RoleRevokedEvent,
-  } from "../generated/templates/OffchainAssetReceiptVaultAuthorizerV1Template/OffchainAssetReceiptVaultAuthorizerV1";
+  OffchainAssetReceiptVaultTemplate,
+  OffchainAssetReceiptVaultAuthorizerV1Template,
+} from "../generated/templates";
+import { ZERO } from "../src/utils";
+import {
+  AuthorizerSet,
+  Certify as CertifyEvent,
+  Deposit,
+  Withdraw,
+  ConfiscateShares as ConfiscateSharesEvent,
+  ConfiscateReceipt as ConfiscateReceiptEvent,
+  OffchainAssetReceiptVaultInitializedV2,
+  Transfer,
+} from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
+import {
+  RoleAdminChanged,
+  RoleGranted as RoleGrantedEvent,
+  RoleRevoked as RoleRevokedEvent,
+} from "../generated/templates/OffchainAssetReceiptVaultAuthorizerV1Template/OffchainAssetReceiptVaultAuthorizerV1";
 
 export class VaultConfig {
-    address: Address;
-    name: String;
-    symbol: String;
-  
-    constructor(address: Address, name: String, symbol: String) {
-      this.address = address;
-      this.name = name;
-      this.symbol = symbol;
-    }
+  address: Address;
+  name: String;
+  symbol: String;
+
+  constructor(address: Address, name: String, symbol: String) {
+    this.address = address;
+    this.name = name;
+    this.symbol = symbol;
+  }
 }
 
 export class ReceiptVaultConfig {
-    vaultConfig: VaultConfig;
-    receipt: Address;
+  vaultConfig: VaultConfig;
+  receipt: Address;
 
-    constructor(vaultConfig: VaultConfig, receipt: Address) {
-        this.vaultConfig = vaultConfig;
-        this.receipt = receipt;
-    }   
+  constructor(vaultConfig: VaultConfig, receipt: Address) {
+    this.vaultConfig = vaultConfig;
+    this.receipt = receipt;
+  }
 }
 
 export class OffchainAssetReceiptVaultConfigV2 {
-    initialAdmin: Address;
-    receiptVaultConfig: ReceiptVaultConfig;
+  initialAdmin: Address;
+  receiptVaultConfig: ReceiptVaultConfig;
 
-    constructor(initialAdmin: Address, receiptVaultConfig: ReceiptVaultConfig) {
-        this.initialAdmin = initialAdmin;
-        this.receiptVaultConfig = receiptVaultConfig;
-    }
+  constructor(initialAdmin: Address, receiptVaultConfig: ReceiptVaultConfig) {
+    this.initialAdmin = initialAdmin;
+    this.receiptVaultConfig = receiptVaultConfig;
+  }
 }
 
 // event NewClone(address sender, address implementation, address clone);
 export function createNewCloneEvent(
-    sender: Address,
-    implementation: Address,
-    clone: Address
-  ): NewClone {
-
-    let mockEvent = newMockEvent();
-    let newCloneEvent = new NewClone(
-        mockEvent.address,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    newCloneEvent.parameters = new Array();
-    newCloneEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    newCloneEvent.parameters.push(
-        new ethereum.EventParam("implementation", ethereum.Value.fromAddress(implementation))
-    );
-    newCloneEvent.parameters.push(
-        new ethereum.EventParam("clone", ethereum.Value.fromAddress(clone))
-    );
-    return newCloneEvent;
+  sender: Address,
+  implementation: Address,
+  clone: Address,
+): NewClone {
+  let mockEvent = newMockEvent();
+  let newCloneEvent = new NewClone(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  newCloneEvent.parameters = new Array();
+  newCloneEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  newCloneEvent.parameters.push(
+    new ethereum.EventParam(
+      "implementation",
+      ethereum.Value.fromAddress(implementation),
+    ),
+  );
+  newCloneEvent.parameters.push(
+    new ethereum.EventParam("clone", ethereum.Value.fromAddress(clone)),
+  );
+  return newCloneEvent;
 }
 
 // event SetAuthorizer(address sender, address authorizer);
 export function createSetAuthorizerEvent(
-        sender: Address,
-        authorizer: Address,
-        contractAddress: Address
-    ): AuthorizerSet {
-    let mockEvent = newMockEvent();
-    let setAuthorizerEvent = new AuthorizerSet(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    setAuthorizerEvent.parameters = new Array();
-    setAuthorizerEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    setAuthorizerEvent.parameters.push(
-        new ethereum.EventParam("authorizer", ethereum.Value.fromAddress(authorizer))
-    );
-    return setAuthorizerEvent;
+  sender: Address,
+  authorizer: Address,
+  contractAddress: Address,
+): AuthorizerSet {
+  let mockEvent = newMockEvent();
+  let setAuthorizerEvent = new AuthorizerSet(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  setAuthorizerEvent.parameters = new Array();
+  setAuthorizerEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  setAuthorizerEvent.parameters.push(
+    new ethereum.EventParam(
+      "authorizer",
+      ethereum.Value.fromAddress(authorizer),
+    ),
+  );
+  return setAuthorizerEvent;
 }
 
 // event Certify(address sender, uint256 certifyUntil, bool forceUntil, bytes data);
 export function createCertifyEvent(
-    sender: Address,
-    certifyUntil: BigInt,
-    force: boolean,
-    data: Bytes,
-    contractAddress: Address
+  sender: Address,
+  certifyUntil: BigInt,
+  force: boolean,
+  data: Bytes,
+  contractAddress: Address,
 ): CertifyEvent {
-    let mockEvent = newMockEvent();
-    let certifyEvent = new CertifyEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,  
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    certifyEvent.parameters = new Array();
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("certifyUntil", ethereum.Value.fromUnsignedBigInt(certifyUntil))
-    );
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("forceUntil", ethereum.Value.fromBoolean(force))
-    );
-    certifyEvent.parameters.push(
-        new ethereum.EventParam("data", ethereum.Value.fromBytes(data))
-    );
-    return certifyEvent;
+  let mockEvent = newMockEvent();
+  let certifyEvent = new CertifyEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  certifyEvent.parameters = new Array();
+  certifyEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  certifyEvent.parameters.push(
+    new ethereum.EventParam(
+      "certifyUntil",
+      ethereum.Value.fromUnsignedBigInt(certifyUntil),
+    ),
+  );
+  certifyEvent.parameters.push(
+    new ethereum.EventParam("forceUntil", ethereum.Value.fromBoolean(force)),
+  );
+  certifyEvent.parameters.push(
+    new ethereum.EventParam("data", ethereum.Value.fromBytes(data)),
+  );
+  return certifyEvent;
 }
 
 //event Deposit(address sender, address owner, uint256 assets, uint256 shares, uint256 id, bytes receiptInformation);
 export function createDepositEvent(
-    sender: Address,
-    owner: Address,
-    amount: BigInt,
-    shares: BigInt,
-    id: BigInt,
-    receiptInformation: Bytes,
-    contractAddress: Address
+  sender: Address,
+  owner: Address,
+  amount: BigInt,
+  shares: BigInt,
+  id: BigInt,
+  receiptInformation: Bytes,
+  contractAddress: Address,
 ): Deposit {
-    let mockEvent = newMockEvent();
-    let depositEvent = new Deposit(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    depositEvent.parameters = new Array();
-    depositEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("assets", ethereum.Value.fromUnsignedBigInt(amount))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("shares", ethereum.Value.fromUnsignedBigInt(shares))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id))
-    );
-    depositEvent.parameters.push(
-        new ethereum.EventParam("receiptInformation", ethereum.Value.fromBytes(receiptInformation))
-    );
-    
-    return depositEvent;
+  let mockEvent = newMockEvent();
+  let depositEvent = new Deposit(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  depositEvent.parameters = new Array();
+  depositEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam(
+      "assets",
+      ethereum.Value.fromUnsignedBigInt(amount),
+    ),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id)),
+  );
+  depositEvent.parameters.push(
+    new ethereum.EventParam(
+      "receiptInformation",
+      ethereum.Value.fromBytes(receiptInformation),
+    ),
+  );
+
+  return depositEvent;
 }
 
 // event Withdraw(address sender, address receiver, address owner, uint256 assets, uint256 shares, uint256 id, bytes receiptInformation);
 export function createWithdrawEvent(
-    sender: Address,
-    receiver: Address,
-    owner: Address,
-    amount: BigInt,
-    shares: BigInt,
-    id: BigInt,
-    receiptInformation: Bytes,
-    contractAddress: Address
+  sender: Address,
+  receiver: Address,
+  owner: Address,
+  amount: BigInt,
+  shares: BigInt,
+  id: BigInt,
+  receiptInformation: Bytes,
+  contractAddress: Address,
 ): Withdraw {
-    let mockEvent = newMockEvent();
-    let withdrawEvent = new Withdraw(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    withdrawEvent.parameters = new Array();
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("assets", ethereum.Value.fromUnsignedBigInt(amount))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("shares", ethereum.Value.fromUnsignedBigInt(shares))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id))
-    );
-    withdrawEvent.parameters.push(
-        new ethereum.EventParam("receiptInformation", ethereum.Value.fromBytes(receiptInformation))
-    );
-    return withdrawEvent;
-    
+  let mockEvent = newMockEvent();
+  let withdrawEvent = new Withdraw(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  withdrawEvent.parameters = new Array();
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("receiver", ethereum.Value.fromAddress(receiver)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam(
+      "assets",
+      ethereum.Value.fromUnsignedBigInt(amount),
+    ),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id)),
+  );
+  withdrawEvent.parameters.push(
+    new ethereum.EventParam(
+      "receiptInformation",
+      ethereum.Value.fromBytes(receiptInformation),
+    ),
+  );
+  return withdrawEvent;
 }
-
 
 //event ConfiscateShares(address sender, address confiscatee, uint256 targetAmount, uint256 confiscated, bytes justification);
 export function createConfiscateSharesEvent(
-    sender: Address,
-    confiscatee: Address,
-    targetAmount: BigInt,
-    confiscated: BigInt,
-    justification: Bytes,
-    contractAddress: Address
+  sender: Address,
+  confiscatee: Address,
+  targetAmount: BigInt,
+  confiscated: BigInt,
+  justification: Bytes,
+  contractAddress: Address,
 ): ConfiscateSharesEvent {
-    let mockEvent = newMockEvent();
-    let confiscateSharesEvent = new ConfiscateSharesEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,  
-        mockEvent.parameters,
-        null
-    );
-    confiscateSharesEvent.parameters = new Array();
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("confiscatee", ethereum.Value.fromAddress(confiscatee))
-    );
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("targetAmount", ethereum.Value.fromUnsignedBigInt(targetAmount))
-    );  
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("confiscated", ethereum.Value.fromUnsignedBigInt(confiscated))
-    );
-    confiscateSharesEvent.parameters.push(
-        new ethereum.EventParam("justification", ethereum.Value.fromBytes(justification))
-    );
-    return confiscateSharesEvent;
+  let mockEvent = newMockEvent();
+  let confiscateSharesEvent = new ConfiscateSharesEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  confiscateSharesEvent.parameters = new Array();
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscatee",
+      ethereum.Value.fromAddress(confiscatee),
+    ),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "targetAmount",
+      ethereum.Value.fromUnsignedBigInt(targetAmount),
+    ),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscated",
+      ethereum.Value.fromUnsignedBigInt(confiscated),
+    ),
+  );
+  confiscateSharesEvent.parameters.push(
+    new ethereum.EventParam(
+      "justification",
+      ethereum.Value.fromBytes(justification),
+    ),
+  );
+  return confiscateSharesEvent;
 }
 
 //event ConfiscateReceipt(address sender, address confiscatee, uint256 id, uint256 targetAmount, uint256 confiscated, bytes justification);
 export function createConfiscateReceiptEvent(
-    sender: Address,
-    confiscatee: Address,
-    id: BigInt,
-    targetAmount: BigInt,
-    confiscated: BigInt,
-    justification: Bytes,
-    contractAddress: Address
+  sender: Address,
+  confiscatee: Address,
+  id: BigInt,
+  targetAmount: BigInt,
+  confiscated: BigInt,
+  justification: Bytes,
+  contractAddress: Address,
 ): ConfiscateReceiptEvent {
-    let mockEvent = newMockEvent();
-    let confiscateReceiptEvent = new ConfiscateReceiptEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    confiscateReceiptEvent.parameters = new Array();
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("confiscatee", ethereum.Value.fromAddress(confiscatee))
-    );
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id))
-    );  
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("targetAmount", ethereum.Value.fromUnsignedBigInt(targetAmount))
-    );
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("confiscated", ethereum.Value.fromUnsignedBigInt(confiscated))
-    );  
-    confiscateReceiptEvent.parameters.push(
-        new ethereum.EventParam("justification", ethereum.Value.fromBytes(justification))
-    );
-    return confiscateReceiptEvent;
+  let mockEvent = newMockEvent();
+  let confiscateReceiptEvent = new ConfiscateReceiptEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  confiscateReceiptEvent.parameters = new Array();
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscatee",
+      ethereum.Value.fromAddress(confiscatee),
+    ),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromUnsignedBigInt(id)),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "targetAmount",
+      ethereum.Value.fromUnsignedBigInt(targetAmount),
+    ),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "confiscated",
+      ethereum.Value.fromUnsignedBigInt(confiscated),
+    ),
+  );
+  confiscateReceiptEvent.parameters.push(
+    new ethereum.EventParam(
+      "justification",
+      ethereum.Value.fromBytes(justification),
+    ),
+  );
+  return confiscateReceiptEvent;
 }
 
 // event OffchainAssetReceiptVaultInitializedV2(address sender, OffchainAssetReceiptVaultConfigV2 config);
@@ -338,183 +394,255 @@ export function createConfiscateReceiptEvent(
 //     address receipt;
 // }
 export function createOffchainAssetReceiptVaultInitializedV2Event(
-    sender: Address,
-    initialAdmin: Address,
-    receiptVaultConfig: ReceiptVaultConfig,
-    contractAddress: Address
+  sender: Address,
+  initialAdmin: Address,
+  receiptVaultConfig: ReceiptVaultConfig,
+  contractAddress: Address,
 ): OffchainAssetReceiptVaultInitializedV2 {
-    let mockEvent = newMockEvent();
-    let offchainAssetReceiptVaultInitializedV2Event = new OffchainAssetReceiptVaultInitializedV2(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
+  let mockEvent = newMockEvent();
+  let offchainAssetReceiptVaultInitializedV2Event =
+    new OffchainAssetReceiptVaultInitializedV2(
+      contractAddress,
+      mockEvent.logIndex,
+      mockEvent.transactionLogIndex,
+      mockEvent.logType,
+      mockEvent.block,
+      mockEvent.transaction,
+      mockEvent.parameters,
+      null,
     );
-    
-    // Create the ReceiptVaultConfigV2 tuple: (asset, name, symbol, receipt)
-    let receiptVaultConfigValues = new ethereum.Tuple();
-    receiptVaultConfigValues.push(ethereum.Value.fromAddress(receiptVaultConfig.vaultConfig.address)); // asset
-    receiptVaultConfigValues.push(ethereum.Value.fromString(receiptVaultConfig.vaultConfig.name.toString())); // name
-    receiptVaultConfigValues.push(ethereum.Value.fromString(receiptVaultConfig.vaultConfig.symbol.toString())); // symbol
-    receiptVaultConfigValues.push(ethereum.Value.fromAddress(receiptVaultConfig.receipt)); // receipt
-    
-    // Create the OffchainAssetReceiptVaultConfigV2 tuple: (initialAdmin, receiptVaultConfig)
-    let configTuple = new ethereum.Tuple();
-    configTuple.push(ethereum.Value.fromAddress(initialAdmin));
-    configTuple.push(ethereum.Value.fromTuple(receiptVaultConfigValues));
-    
-    offchainAssetReceiptVaultInitializedV2Event.parameters = new Array();
-    offchainAssetReceiptVaultInitializedV2Event.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    offchainAssetReceiptVaultInitializedV2Event.parameters.push(
-        new ethereum.EventParam("config", ethereum.Value.fromTuple(configTuple))
-    );
-    
-    return offchainAssetReceiptVaultInitializedV2Event;
+
+  // Create the ReceiptVaultConfigV2 tuple: (asset, name, symbol, receipt)
+  let receiptVaultConfigValues = new ethereum.Tuple();
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromAddress(receiptVaultConfig.vaultConfig.address),
+  ); // asset
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromString(receiptVaultConfig.vaultConfig.name.toString()),
+  ); // name
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromString(receiptVaultConfig.vaultConfig.symbol.toString()),
+  ); // symbol
+  receiptVaultConfigValues.push(
+    ethereum.Value.fromAddress(receiptVaultConfig.receipt),
+  ); // receipt
+
+  // Create the OffchainAssetReceiptVaultConfigV2 tuple: (initialAdmin, receiptVaultConfig)
+  let configTuple = new ethereum.Tuple();
+  configTuple.push(ethereum.Value.fromAddress(initialAdmin));
+  configTuple.push(ethereum.Value.fromTuple(receiptVaultConfigValues));
+
+  offchainAssetReceiptVaultInitializedV2Event.parameters = new Array();
+  offchainAssetReceiptVaultInitializedV2Event.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  offchainAssetReceiptVaultInitializedV2Event.parameters.push(
+    new ethereum.EventParam("config", ethereum.Value.fromTuple(configTuple)),
+  );
+
+  return offchainAssetReceiptVaultInitializedV2Event;
 }
 //event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
 export function createRoleAdminChangedEvent(
-    role: Bytes,
-    previousAdminRole: Bytes,
-    newAdminRole: Bytes,
-    contractAddress: Address
+  role: Bytes,
+  previousAdminRole: Bytes,
+  newAdminRole: Bytes,
+  contractAddress: Address,
 ): RoleAdminChanged {
-    let mockEvent = newMockEvent();
-    let roleAdminChangedEvent = new RoleAdminChanged(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    roleAdminChangedEvent.parameters = new Array();
-    roleAdminChangedEvent.parameters.push(
-        new ethereum.EventParam("role", ethereum.Value.fromBytes(role))
-    );
-    roleAdminChangedEvent.parameters.push(
-        new ethereum.EventParam("previousAdminRole", ethereum.Value.fromBytes(previousAdminRole))
-    );
-    roleAdminChangedEvent.parameters.push(
-        new ethereum.EventParam("newAdminRole", ethereum.Value.fromBytes(newAdminRole))
-    );
-    return roleAdminChangedEvent;
-}   
+  let mockEvent = newMockEvent();
+  let roleAdminChangedEvent = new RoleAdminChanged(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  roleAdminChangedEvent.parameters = new Array();
+  roleAdminChangedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromBytes(role)),
+  );
+  roleAdminChangedEvent.parameters.push(
+    new ethereum.EventParam(
+      "previousAdminRole",
+      ethereum.Value.fromBytes(previousAdminRole),
+    ),
+  );
+  roleAdminChangedEvent.parameters.push(
+    new ethereum.EventParam(
+      "newAdminRole",
+      ethereum.Value.fromBytes(newAdminRole),
+    ),
+  );
+  return roleAdminChangedEvent;
+}
 
 // event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
 export function createRoleGrantedEvent(
-    role: Bytes,
-    account: Address,
-    sender: Address,    
-    contractAddress: Address
+  role: Bytes,
+  account: Address,
+  sender: Address,
+  contractAddress: Address,
 ): RoleGrantedEvent {
-    let mockEvent = newMockEvent();
-    let roleGrantedEvent = new RoleGrantedEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );  
-    roleGrantedEvent.parameters = new Array();
-    roleGrantedEvent.parameters.push(
-        new ethereum.EventParam("role", ethereum.Value.fromBytes(role))
-    );  
-    roleGrantedEvent.parameters.push(
-        new ethereum.EventParam("account", ethereum.Value.fromAddress(account))
-    );  
-    roleGrantedEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );  
-    return roleGrantedEvent;
+  let mockEvent = newMockEvent();
+  let roleGrantedEvent = new RoleGrantedEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  roleGrantedEvent.parameters = new Array();
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromBytes(role)),
+  );
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(account)),
+  );
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  return roleGrantedEvent;
 }
 
 //event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
 export function createRoleRevokedEvent(
-    role: Bytes,
-    account: Address,
-    sender: Address,
-    contractAddress: Address
+  role: Bytes,
+  account: Address,
+  sender: Address,
+  contractAddress: Address,
 ): RoleRevokedEvent {
-    let mockEvent = newMockEvent();
-    let roleRevokedEvent = new RoleRevokedEvent(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,  
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );  
-    roleRevokedEvent.parameters = new Array();
-    roleRevokedEvent.parameters.push(
-        new ethereum.EventParam("role", ethereum.Value.fromBytes(role))
-    );  
-    roleRevokedEvent.parameters.push(
-        new ethereum.EventParam("account", ethereum.Value.fromAddress(account))
-    );  
-    roleRevokedEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );  
-    return roleRevokedEvent;
+  let mockEvent = newMockEvent();
+  let roleRevokedEvent = new RoleRevokedEvent(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  roleRevokedEvent.parameters = new Array();
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromBytes(role)),
+  );
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(account)),
+  );
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  return roleRevokedEvent;
 }
 
 // event Deployment(address sender, address asset, address wrapper);
 export function createDeploymentEvent(
-    sender: Address,
-    asset: Address,
-    wrapper: Address,
-    contractAddress: Address
+  sender: Address,
+  asset: Address,
+  wrapper: Address,
+  contractAddress: Address,
 ): Deployment {
-    let mockEvent = newMockEvent();
-    let deploymentEvent = new Deployment(
-        contractAddress,
-        mockEvent.logIndex,
-        mockEvent.transactionLogIndex,
-        mockEvent.logType,
-        mockEvent.block,
-        mockEvent.transaction,
-        mockEvent.parameters,
-        null
-    );
-    deploymentEvent.parameters = new Array();
-    deploymentEvent.parameters.push(
-        new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
-    );
-    deploymentEvent.parameters.push(
-        new ethereum.EventParam("asset", ethereum.Value.fromAddress(asset))
-    );
-    deploymentEvent.parameters.push(
-        new ethereum.EventParam("wrapper", ethereum.Value.fromAddress(wrapper))
-    );
-    return deploymentEvent;
+  let mockEvent = newMockEvent();
+  let deploymentEvent = new Deployment(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  deploymentEvent.parameters = new Array();
+  deploymentEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  deploymentEvent.parameters.push(
+    new ethereum.EventParam("asset", ethereum.Value.fromAddress(asset)),
+  );
+  deploymentEvent.parameters.push(
+    new ethereum.EventParam("wrapper", ethereum.Value.fromAddress(wrapper)),
+  );
+  return deploymentEvent;
 }
 
 export function createMockERC20Functions(address: Address): void {
-    createMockedFunction(address, "name", "name():(string)")
-      .withArgs([])
-      .returns([ethereum.Value.fromString("Test")]);
-    createMockedFunction(address, "symbol", "symbol():(string)")
-      .withArgs([])
-      .returns([ethereum.Value.fromString("TST")]);
-    createMockedFunction(address, "decimals", "decimals():(uint8)")
-      .withArgs([])
-      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(18))]);
-  }
+  createMockedFunction(address, "name", "name():(string)")
+    .withArgs([])
+    .returns([ethereum.Value.fromString("Test")]);
+  createMockedFunction(address, "symbol", "symbol():(string)")
+    .withArgs([])
+    .returns([ethereum.Value.fromString("TST")]);
+  createMockedFunction(address, "decimals", "decimals():(uint8)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(18))]);
+}
 
-export function createMockReceiptFunction(vaultAddress: Address, receiptAddress: Address): void {
-    createMockedFunction(vaultAddress, "receipt", "receipt():(address)")
-      .withArgs([])
-      .returns([ethereum.Value.fromAddress(receiptAddress)]);
-  }
+export function createMockReceiptFunction(
+  vaultAddress: Address,
+  receiptAddress: Address,
+): void {
+  createMockedFunction(vaultAddress, "receipt", "receipt():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(receiptAddress)]);
+}
+
+// event Transfer(address indexed from, address indexed to, uint256 value);
+export function createTransferEvent(
+  from: Address,
+  to: Address,
+  value: BigInt,
+  contractAddress: Address,
+): Transfer {
+  let mockEvent = newMockEvent();
+  let transferEvent = new Transfer(
+    contractAddress,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    null,
+  );
+  transferEvent.parameters = new Array();
+  transferEvent.parameters.push(
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from)),
+  );
+  transferEvent.parameters.push(
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to)),
+  );
+  transferEvent.parameters.push(
+    new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value)),
+  );
+  return transferEvent;
+}
+
+export function createMockBalanceOfFunction(
+  vaultAddress: Address,
+  holder: Address,
+  balance: BigInt,
+): void {
+  createMockedFunction(
+    vaultAddress,
+    "balanceOf",
+    "balanceOf(address):(uint256)",
+  )
+    .withArgs([ethereum.Value.fromAddress(holder)])
+    .returns([ethereum.Value.fromUnsignedBigInt(balance)]);
+}
+
+export function createMockTotalSupplyFunction(
+  vaultAddress: Address,
+  totalSupply: BigInt,
+): void {
+  createMockedFunction(vaultAddress, "totalSupply", "totalSupply():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(totalSupply)]);
+}


### PR DESCRIPTION
## Summary
- Add `tokenHolderCount`, `shareTransferCount`, `depositVolume`, and `withdrawVolume` to `OffchainAssetReceiptVault`
- Maintain aggregates incrementally in deposit, withdraw, and share transfer handlers
- Add matchstick coverage for deployment defaults, deposit/withdraw volumes, and transfer-driven holder/transfer counts

Stacks on #25 so the REST API can fetch all token summaries in one batched `offchainAssetReceiptVaults` query instead of paginating subgraph entities per token at request time.

## Test plan
- [x] `graph build`
- [x] `graph test -d` (requires Docker)
- [x] Re-index and verify aggregates match prior REST scan semantics on live vaults


Made with [Cursor](https://cursor.com)