### PR TITLE
Store confiscation justification as Bytes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -323,8 +323,8 @@ type ConfiscateShares implements Event @entity {
   confiscatee: Account! # ConfiscateShares.confiscatee
   "The number of shares confiscated"
   confiscated: BigInt! # ConfiscateShares.confiscated
-  "data"
-  data: String!
+  "The justification / metadata submitted with the confiscation (Rain Metadata V1 bytes)"
+  data: Bytes! # ConfiscateShares.justification
 }
 
 # Get from event ConfiscateReceipt
@@ -346,8 +346,8 @@ type ConfiscateReceipt implements Event @entity {
   receipt: Receipt! # Link to Receipt for {OffchainAssetReceiptVault address}-{Confiscate.id}
   "The number of receipts confiscated"
   confiscated: BigInt! # ConfiscateReceipt.confiscated
-  "data"
-  data: String!
+  "The justification / metadata submitted with the confiscation (Rain Metadata V1 bytes)"
+  data: Bytes! # ConfiscateReceipt.justification
 }
 
 type SharesBalance @entity {

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -199,7 +199,8 @@ export function handleConfiscateReceipt(event: ConfiscateReceiptEvent): void {
 
     confiscateReceipts.confiscated = event.params.confiscated;
     confiscateReceipts.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
-    confiscateReceipts.data = event.params.justification.toString();
+    // Store as Bytes (not .toString()) so Rain Metadata V1 binary survives indexing.
+    confiscateReceipts.data = event.params.justification;
     confiscateReceipts.save();
   }
 }
@@ -231,7 +232,8 @@ export function handleConfiscateShares(event: ConfiscateSharesEvent): void {
     ).id;
     confiscateShares.confiscated = event.params.confiscated;
     confiscateShares.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
-    confiscateShares.data = event.params.justification.toString();
+    // Store as Bytes (not .toString()) so Rain Metadata V1 binary survives indexing.
+    confiscateShares.data = event.params.justification;
     confiscateShares.save();
   }
 }

--- a/tests/handleConfiscateReceipt.test.ts
+++ b/tests/handleConfiscateReceipt.test.ts
@@ -1,21 +1,27 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock,
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
 } from "matchstick-as";
 import {
-    Address,
-    Bytes,
-    DataSourceContext,
-    Value,
-    BigInt
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
 } from "@graphprotocol/graph-ts";
-import { createNewCloneEvent, createMockERC20Functions, createConfiscateReceiptEvent, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+import {
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createConfiscateReceiptEvent,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
@@ -23,139 +29,156 @@ import { handleConfiscateReceipt } from "../src/OffchainAssetReceiptVault";
 import { getAccount, getReceipt } from "../src/utils";
 
 describe("Confiscate Receipt Test", () => {
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A';
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
 
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    test("handle confiscate receipt", () => {
-        const confiscator = Address.fromString("0x1234567890123456789012345678901234567890");
-        const depositor = Address.fromString("0x1234567890123456789012345678901234567891");
+  test("handle confiscate receipt", () => {
+    const confiscator = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const depositor = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receiptAddress = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receiptAddress);
-        let deploymentEvent = createDeploymentEvent(depositor, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receiptAddress = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receiptAddress);
+    let deploymentEvent = createDeploymentEvent(
+      depositor,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent = createNewCloneEvent(depositor, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      depositor,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        createMockERC20Functions(assetVaultClone);
+    createMockERC20Functions(assetVaultClone);
 
-        const confiscateReceiptEvent = createConfiscateReceiptEvent(
-            confiscator,
-            depositor,
-            BigInt.fromString("1"),
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1000000000000000000"),
-            Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
-            assetVaultClone
-        );
+    const confiscateReceiptEvent = createConfiscateReceiptEvent(
+      confiscator,
+      depositor,
+      BigInt.fromString("1"),
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1000000000000000000"),
+      Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
+      assetVaultClone,
+    );
 
-        handleConfiscateReceipt(confiscateReceiptEvent);
+    handleConfiscateReceipt(confiscateReceiptEvent);
 
-        assert.entityCount("ConfiscateReceipt", 1);
+    assert.entityCount("ConfiscateReceipt", 1);
 
-        const confiscateReceiptId = `ConfiscateReceipt-${confiscateReceiptEvent.transaction.hash.toHex()}`;
-        const confiscatorAccount = getAccount(
-            confiscator.toHex(),
-            assetVaultClone.toHex()
-        ).id;
-        const confiscateeAccount = getAccount(
-            depositor.toHex(),
-            assetVaultClone.toHex()
-        ).id;
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "id",
-            confiscateReceiptId
-        );
+    const confiscateReceiptId = `ConfiscateReceipt-${confiscateReceiptEvent.transaction.hash.toHex()}`;
+    const confiscatorAccount = getAccount(
+      confiscator.toHex(),
+      assetVaultClone.toHex(),
+    ).id;
+    const confiscateeAccount = getAccount(
+      depositor.toHex(),
+      assetVaultClone.toHex(),
+    ).id;
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "id",
+      confiscateReceiptId,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "timestamp",
-            confiscateReceiptEvent.block.timestamp.toString()
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "timestamp",
+      confiscateReceiptEvent.block.timestamp.toString(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "transaction",
-            confiscateReceiptEvent.transaction.hash.toHex()
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "transaction",
+      confiscateReceiptEvent.transaction.hash.toHex(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "emitter",
-            confiscatorAccount
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "emitter",
+      confiscatorAccount,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "confiscatee",
-            confiscateeAccount
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "confiscatee",
+      confiscateeAccount,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "confiscator",
-            confiscatorAccount
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "confiscator",
+      confiscatorAccount,
+    );
 
-        const receipt = getReceipt  (
-            assetVaultClone.toHex(),
-            BigInt.fromString("1")
-        );
+    const receipt = getReceipt(assetVaultClone.toHex(), BigInt.fromString("1"));
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "receipt",
-            receipt.id
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "receipt",
+      receipt.id,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "confiscated",
-            confiscateReceiptEvent.params.confiscated.toString()
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "confiscated",
+      confiscateReceiptEvent.params.confiscated.toString(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateReceipt",
-            confiscateReceiptId,
-            "data",
-            confiscateReceiptEvent.params.justification.toString()
-        );
-        
-    })
-
-})
-                
+    assert.fieldEquals(
+      "ConfiscateReceipt",
+      confiscateReceiptId,
+      "data",
+      confiscateReceiptEvent.params.justification.toHex(),
+    );
+  });
+});

--- a/tests/handleConfiscateShares.test.ts
+++ b/tests/handleConfiscateShares.test.ts
@@ -1,21 +1,27 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock,
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
 } from "matchstick-as";
 import {
-    Address,
-    Bytes,
-    DataSourceContext,
-    Value,
-    BigInt
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
 } from "@graphprotocol/graph-ts";
-import { createNewCloneEvent, createMockERC20Functions, createConfiscateSharesEvent, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+import {
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createConfiscateSharesEvent,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
@@ -23,112 +29,136 @@ import { handleConfiscateShares } from "../src/OffchainAssetReceiptVault";
 import { getAccount } from "../src/utils";
 
 describe("Confiscate Shares Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
 
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A';
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  test("handle confiscate shares", () => {
+    const confiscator = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const depositor = Address.fromString(
+      "0x1234567890123456789012345678901234567891",
+    );
 
-    test("handle confiscate shares", () => {
-        const confiscator = Address.fromString("0x1234567890123456789012345678901234567890");
-        const depositor = Address.fromString("0x1234567890123456789012345678901234567891");
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      depositor,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(depositor, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      depositor,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent = createNewCloneEvent(depositor, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    createMockERC20Functions(assetVaultClone);
 
-        createMockERC20Functions(assetVaultClone);
+    const confiscateSharesEvent = createConfiscateSharesEvent(
+      confiscator,
+      depositor,
+      BigInt.fromString("1000000000000000000"),
+      BigInt.fromString("1000000000000000000"),
+      Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
+      assetVaultClone,
+    );
+    handleConfiscateShares(confiscateSharesEvent);
 
-        const confiscateSharesEvent = createConfiscateSharesEvent(
-            confiscator,
-            depositor,
-            BigInt.fromString("1000000000000000000"),
-            BigInt.fromString("1000000000000000000"),
-            Bytes.fromHexString("0x1234567890123456789012345678901234567890"),
-            assetVaultClone
-        );
-        handleConfiscateShares(confiscateSharesEvent);
+    assert.entityCount("ConfiscateShares", 1);
 
-        assert.entityCount("ConfiscateShares", 1);
+    const confiscateSharesId = `ConfiscateShares-${confiscateSharesEvent.transaction.hash.toHex()}`;
+    const emitter = getAccount(confiscator.toHex(), assetVaultClone.toHex()).id;
+    const confiscatee = getAccount(
+      depositor.toHex(),
+      assetVaultClone.toHex(),
+    ).id;
 
-        const confiscateSharesId = `ConfiscateShares-${confiscateSharesEvent.transaction.hash.toHex()}`;
-        const emitter = getAccount(confiscator.toHex(), assetVaultClone.toHex()).id;
-        const confiscatee = getAccount(depositor.toHex(), assetVaultClone.toHex()).id;
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "id",
+      confiscateSharesId,
+    );
 
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "timestamp",
+      confiscateSharesEvent.block.timestamp.toString(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "id",
-            confiscateSharesId
-        );
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "emitter",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "timestamp",
-            confiscateSharesEvent.block.timestamp.toString()
-        );
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "confiscatee",
+      confiscatee,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "emitter",
-            emitter
-        );
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "confiscator",
+      emitter,
+    );
 
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "confiscatee",
-            confiscatee
-        );
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "confiscated",
+      confiscateSharesEvent.params.confiscated.toString(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "confiscator",
-            emitter
-        );
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
 
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "confiscated",
-            confiscateSharesEvent.params.confiscated.toString()
-        );
-
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "offchainAssetReceiptVault",
-            assetVaultClone.toHex()
-        );
-
-        assert.fieldEquals(
-            "ConfiscateShares",
-            confiscateSharesId,
-            "data",
-            confiscateSharesEvent.params.justification.toString()
-        );
-    })
-})
+    assert.fieldEquals(
+      "ConfiscateShares",
+      confiscateSharesId,
+      "data",
+      confiscateSharesEvent.params.justification.toHex(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Change `ConfiscateShares.data` and `ConfiscateReceipt.data` from `String!` to `Bytes!`
- Persist event `justification` as raw Bytes in handlers instead of `.toString()`, so Rain Metadata V1 binary survives indexing
- Update Matchstick assertions to compare via `.toHex()`

## Test plan
- [ ] `graph build`
- [ ] `graph test -d` (or CI Matchstick run)
- [ ] Confirm confiscation entities expose `data` as hex bytes after re-index


Made with [Cursor](https://cursor.com)