### PR TITLE
Use a workflow input for Goldsky deploy versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,10 @@ on:
           - sepolia
           - songbird
           - linea
+      version:
+        description: "Goldsky subgraph version (e.g. 1.0.13). Current base is 1.0.12 — bump when deploying."
+        required: true
+        type: string
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -38,5 +42,5 @@ jobs:
       # Check if the repo is clean before deploying.
       - run: git diff --exit-code -- . ":(exclude)subgraph.yaml"
       - run: >
-          nix develop -c goldsky subgraph deploy "sft-${{ inputs.network }}/$(git rev-parse --short HEAD)"
+          nix develop -c goldsky subgraph deploy "sft-${{ inputs.network }}/${{ inputs.version }}"
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,19 @@ npm test
 ## Deploy
 
 Deployments are triggered manually from GitHub Actions (**Deploy subgraph**
-workflow). Pick a network and the workflow will:
+workflow). Provide:
+
+- **network** — target chain
+- **version** — Goldsky subgraph version string (e.g. `1.0.13`)
+
+The workflow will:
 
 1. Build contract artifacts and the subgraph
-2. Deploy to Goldsky as `sft-<network>/<git-short-sha>`
+2. Deploy to Goldsky as `sft-<network>/<version>`
 
-The deploy version is the short git commit SHA of the checked-out ref, so each
-deployment is traceable to an exact commit.
+Bump the version for each new deploy of a network (current `base` is `1.0.12`).
+Reusing an existing version name will fail or overwrite depending on Goldsky
+behavior — prefer always bumping.
 
 Requires the `CI_GOLDSKY_TOKEN` repository secret.
 


### PR DESCRIPTION
## Summary
- Add a required `version` input to the Deploy subgraph workflow
- Deploy as `sft-<network>/<version>` instead of `sft-<network>/<git-short-sha>`
- Document the new input in the README (current `base` version: `1.0.12`)

## Usage
When running the workflow, set e.g.:
- network: `base`
- version: `1.0.13`

Made with [Cursor](https://cursor.com)