### PR TITLE
Add VaultDayStat per-UTC-day vault aggregates

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -125,6 +125,8 @@ type VaultDayStat @entity {
   depositVolume: BigInt!
   "Sum of withdraw amounts (shares) on this day"
   withdrawVolume: BigInt!
+  "Sum of wallet-to-wallet SharesTransfer valueExact on this day"
+  transferVolume: BigInt!
 }
 
 type Authorizer @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -87,6 +87,8 @@ type OffchainAssetReceiptVault @entity {
   depositVolume: BigInt!
   "Sum of WithdrawWithReceipt.amount for this vault"
   withdrawVolume: BigInt!
+  "Per-UTC-day deposit/withdraw/transfer aggregates for dashboard charts"
+  dayStats: [VaultDayStat!]! @derivedFrom(field: "offchainAssetReceiptVault")
   "Wrapped ERC20 token transfers for this vault (wallet-to-wallet)"
   wrappedTokenTransfers: [WrappedTokenTransfer!]
     @derivedFrom(field: "offchainAssetReceiptVault")
@@ -98,6 +100,31 @@ type OffchainAssetReceiptVault @entity {
   exchangeRateBlock: BigInt
   "Timestamp when wrapped exchange rates were last updated"
   exchangeRateTimestamp: BigInt
+}
+
+"""
+One row per vault per UTC calendar day.
+Lets the home dashboard chart deposits/withdraws/transfers without paginating
+every DepositWithReceipt / WithdrawWithReceipt / SharesTransfer event.
+Updated incrementally in deposit / withdraw / share-transfer handlers.
+"""
+type VaultDayStat @entity {
+  " {vaultAddress}-{dayStartUnix} where dayStartUnix is UTC midnight "
+  id: ID!
+  "Vault this day bucket belongs to"
+  offchainAssetReceiptVault: OffchainAssetReceiptVault!
+  "Unix timestamp of UTC midnight for this day"
+  day: BigInt!
+  "Number of DepositWithReceipt events on this day"
+  depositCount: BigInt!
+  "Number of WithdrawWithReceipt events on this day"
+  withdrawCount: BigInt!
+  "Number of SharesTransfer events on this day"
+  transferCount: BigInt!
+  "Sum of deposit amounts (shares) on this day"
+  depositVolume: BigInt!
+  "Sum of withdraw amounts (shares) on this day"
+  withdrawVolume: BigInt!
 }
 
 type Authorizer @entity {

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -580,6 +580,7 @@ export function handleTransfer(event: Transfer): void {
   if (!isMint && !isBurn) {
     let dayStat = getOrCreateVaultDayStat(vault.id, event.block.timestamp);
     dayStat.transferCount = dayStat.transferCount.plus(ONE);
+    dayStat.transferVolume = dayStat.transferVolume.plus(event.params.value);
     dayStat.save();
   }
 

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -35,6 +35,7 @@ import {
 } from "../generated/templates/OffchainAssetReceiptVaultTemplate/OffchainAssetReceiptVault";
 import {
   getAccount,
+  getOrCreateVaultDayStat,
   getReceipt,
   getReceiptBalance,
   getTransaction,
@@ -304,6 +305,14 @@ export function handleDeposit(event: Deposit): void {
       offchainAssetReceiptVault.depositVolume.plus(event.params.shares);
     offchainAssetReceiptVault.save();
 
+    let dayStat = getOrCreateVaultDayStat(
+      offchainAssetReceiptVault.id,
+      event.block.timestamp,
+    );
+    dayStat.depositCount = dayStat.depositCount.plus(ONE);
+    dayStat.depositVolume = dayStat.depositVolume.plus(event.params.shares);
+    dayStat.save();
+
     let account = getAccount(
       event.params.owner.toHex(),
       offchainAssetReceiptVault.id,
@@ -566,6 +575,14 @@ export function handleTransfer(event: Transfer): void {
 
   st.save();
   vault.shareTransferCount = vault.shareTransferCount.plus(ONE);
+
+  // Day-bucket wallet-to-wallet transfers only (exclude mint/burn from deposit/withdraw)
+  if (!isMint && !isBurn) {
+    let dayStat = getOrCreateVaultDayStat(vault.id, event.block.timestamp);
+    dayStat.transferCount = dayStat.transferCount.plus(ONE);
+    dayStat.save();
+  }
+
   vault.save();
 }
 
@@ -631,5 +648,13 @@ export function handleWithdraw(event: Withdraw): void {
     offchainAssetReceiptVault.withdrawVolume =
       offchainAssetReceiptVault.withdrawVolume.plus(event.params.shares);
     offchainAssetReceiptVault.save();
+
+    let dayStat = getOrCreateVaultDayStat(
+      offchainAssetReceiptVault.id,
+      event.block.timestamp,
+    );
+    dayStat.withdrawCount = dayStat.withdrawCount.plus(ONE);
+    dayStat.withdrawVolume = dayStat.withdrawVolume.plus(event.params.shares);
+    dayStat.save();
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,6 +116,7 @@ export function getOrCreateVaultDayStat(
     dayStat.transferCount = ZERO;
     dayStat.depositVolume = ZERO;
     dayStat.withdrawVolume = ZERO;
+    dayStat.transferVolume = ZERO;
   }
   return dayStat;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,4 @@
 import {
-  Address,
-  BigDecimal,
-  BigInt,
-  ByteArray,
-  Bytes,
-  ethereum,
-} from "@graphprotocol/graph-ts";
-import {
   Account,
   Authorizer,
   OffchainAssetReceiptVault,
@@ -16,13 +8,23 @@ import {
   TokenHolder,
   Transaction,
   User,
+  VaultDayStat,
 } from "../generated/schema";
+import {
+  Address,
+  BigDecimal,
+  BigInt,
+  ByteArray,
+  Bytes,
+  ethereum,
+} from "@graphprotocol/graph-ts";
 
 export const ZERO = BigInt.fromI32(0);
 export const ONE = BigInt.fromI32(1);
 export const ONE_18 = BigInt.fromString("1000000000000000000");
 export const ZERO_BD = BigDecimal.fromString("0");
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+export const SECONDS_PER_DAY = BigInt.fromI32(86400);
 
 export function getAccount(
   address: string,
@@ -92,6 +94,30 @@ export function getTransaction(
     transaction.save();
   }
   return transaction as Transaction;
+}
+
+/**
+ * Get or create a UTC-day bucket for vault activity.
+ * Id: `{vaultId}-{dayStartUnix}` where dayStartUnix = floor(timestamp / 86400) * 86400.
+ */
+export function getOrCreateVaultDayStat(
+  vaultId: string,
+  timestamp: BigInt,
+): VaultDayStat {
+  let dayStart = timestamp.div(SECONDS_PER_DAY).times(SECONDS_PER_DAY);
+  let id = vaultId + "-" + dayStart.toString();
+  let dayStat = VaultDayStat.load(id);
+  if (!dayStat) {
+    dayStat = new VaultDayStat(id);
+    dayStat.offchainAssetReceiptVault = vaultId;
+    dayStat.day = dayStart;
+    dayStat.depositCount = ZERO;
+    dayStat.withdrawCount = ZERO;
+    dayStat.transferCount = ZERO;
+    dayStat.depositVolume = ZERO;
+    dayStat.withdrawVolume = ZERO;
+  }
+  return dayStat;
 }
 
 export function getRoleHolder(

--- a/tests/handleVaultDayStat.test.ts
+++ b/tests/handleVaultDayStat.test.ts
@@ -147,6 +147,7 @@ describe("VaultDayStat Test", () => {
     assert.fieldEquals("VaultDayStat", id, "transferCount", "0");
     assert.fieldEquals("VaultDayStat", id, "depositVolume", shares.toString());
     assert.fieldEquals("VaultDayStat", id, "withdrawVolume", "0");
+    assert.fieldEquals("VaultDayStat", id, "transferVolume", "0");
   });
 
   test("same-day deposits accumulate on one VaultDayStat", () => {
@@ -422,10 +423,11 @@ describe("VaultDayStat Test", () => {
     const id = dayStatId(assetVaultClone.toHex(), BigInt.fromI32(86400 * 100));
     assert.entityCount("VaultDayStat", 1);
     assert.fieldEquals("VaultDayStat", id, "transferCount", "1");
+    assert.fieldEquals("VaultDayStat", id, "transferVolume", half.toString());
     assert.fieldEquals("VaultDayStat", id, "depositCount", "0");
     assert.fieldEquals("VaultDayStat", id, "withdrawCount", "0");
 
-    // Burn (to zero) — must not bump transferCount
+    // Burn (to zero) — must not bump transferCount/volume
     createMockBalanceOfFunction(assetVaultClone, recipient, ZERO);
     createMockTotalSupplyFunction(assetVaultClone, half);
     const burn = createTransferEvent(recipient, zero, half, assetVaultClone);
@@ -434,5 +436,6 @@ describe("VaultDayStat Test", () => {
 
     assert.entityCount("VaultDayStat", 1);
     assert.fieldEquals("VaultDayStat", id, "transferCount", "1");
+    assert.fieldEquals("VaultDayStat", id, "transferVolume", half.toString());
   });
 });

--- a/tests/handleVaultDayStat.test.ts
+++ b/tests/handleVaultDayStat.test.ts
@@ -44,28 +44,35 @@ function dayStatId(vaultId: string, timestamp: BigInt): string {
   return vaultId + "-" + dayStart(timestamp).toString();
 }
 
+function deployVault(
+  deployer: Address,
+  assetVaultClone: Address,
+  receipt: Address,
+  wrapper: Address,
+  authorizerClone: Address,
+  dataSourceAddress: string,
+): void {
+  createMockReceiptFunction(assetVaultClone, receipt);
+  handleDeployment(
+    createDeploymentEvent(
+      deployer,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    ),
+  );
+  handleNewClone(
+    createNewCloneEvent(
+      deployer,
+      Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS),
+      authorizerClone,
+    ),
+  );
+  createMockERC20Functions(assetVaultClone);
+}
+
 describe("VaultDayStat Test", () => {
   const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
-  const deployer = Address.fromString(
-    "0x1234567890123456789012345678901234567890",
-  );
-  const assetVaultClone = Address.fromString(
-    "0x0000000000000000000000000000000000aaaaaa",
-  );
-  const receipt = Address.fromString(
-    "0x0000000000000000000000000000000000cccccc",
-  );
-  const wrapper = Address.fromString(
-    "0x0000000000000000000000000000000000dddddd",
-  );
-  const authorizerClone = Address.fromString(
-    "0x0000000000000000000000000000000000bbbbbb",
-  );
-
-  // UTC day 100 and day 101 midnights, plus an hour into day 100
-  const day100 = BigInt.fromI32(86400 * 100);
-  const day100Noon = day100.plus(BigInt.fromI32(3600));
-  const day101 = BigInt.fromI32(86400 * 101);
 
   beforeAll(() => {
     let context = new DataSourceContext();
@@ -78,28 +85,31 @@ describe("VaultDayStat Test", () => {
     clearInBlockStore();
   });
 
-  function deployVault(): void {
-    createMockReceiptFunction(assetVaultClone, receipt);
-    handleDeployment(
-      createDeploymentEvent(
-        deployer,
-        assetVaultClone,
-        wrapper,
-        Address.fromString(dataSourceAddress),
-      ),
-    );
-    handleNewClone(
-      createNewCloneEvent(
-        deployer,
-        Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS),
-        authorizerClone,
-      ),
-    );
-    createMockERC20Functions(assetVaultClone);
-  }
-
   test("deposit creates VaultDayStat bucket with counts and volume", () => {
-    deployVault();
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+
+    deployVault(
+      deployer,
+      assetVaultClone,
+      receipt,
+      wrapper,
+      authorizerClone,
+      dataSourceAddress,
+    );
 
     const shares = BigInt.fromString("1000000000000000000");
     const depositEvent = createDepositEvent(
@@ -111,10 +121,13 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    depositEvent.block.timestamp = day100Noon;
+    depositEvent.block.timestamp = BigInt.fromI32(86400 * 100 + 3600);
     handleDeposit(depositEvent);
 
-    const id = dayStatId(assetVaultClone.toHex(), day100Noon);
+    const id = dayStatId(
+      assetVaultClone.toHex(),
+      BigInt.fromI32(86400 * 100 + 3600),
+    );
     assert.entityCount("VaultDayStat", 1);
     assert.fieldEquals("VaultDayStat", id, "id", id);
     assert.fieldEquals(
@@ -123,7 +136,12 @@ describe("VaultDayStat Test", () => {
       "offchainAssetReceiptVault",
       assetVaultClone.toHex(),
     );
-    assert.fieldEquals("VaultDayStat", id, "day", day100.toString());
+    assert.fieldEquals(
+      "VaultDayStat",
+      id,
+      "day",
+      BigInt.fromI32(86400 * 100).toString(),
+    );
     assert.fieldEquals("VaultDayStat", id, "depositCount", "1");
     assert.fieldEquals("VaultDayStat", id, "withdrawCount", "0");
     assert.fieldEquals("VaultDayStat", id, "transferCount", "0");
@@ -132,7 +150,30 @@ describe("VaultDayStat Test", () => {
   });
 
   test("same-day deposits accumulate on one VaultDayStat", () => {
-    deployVault();
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+
+    deployVault(
+      deployer,
+      assetVaultClone,
+      receipt,
+      wrapper,
+      authorizerClone,
+      dataSourceAddress,
+    );
 
     const shares1 = BigInt.fromString("1000000000000000000");
     const shares2 = BigInt.fromString("2000000000000000000");
@@ -146,7 +187,7 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    deposit1.block.timestamp = day100;
+    deposit1.block.timestamp = BigInt.fromI32(86400 * 100);
     handleDeposit(deposit1);
 
     const deposit2 = createDepositEvent(
@@ -158,10 +199,10 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    deposit2.block.timestamp = day100Noon;
+    deposit2.block.timestamp = BigInt.fromI32(86400 * 100 + 3600);
     handleDeposit(deposit2);
 
-    const id = dayStatId(assetVaultClone.toHex(), day100);
+    const id = dayStatId(assetVaultClone.toHex(), BigInt.fromI32(86400 * 100));
     assert.entityCount("VaultDayStat", 1);
     assert.fieldEquals("VaultDayStat", id, "depositCount", "2");
     assert.fieldEquals(
@@ -173,7 +214,30 @@ describe("VaultDayStat Test", () => {
   });
 
   test("deposits on different UTC days create separate VaultDayStat rows", () => {
-    deployVault();
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+
+    deployVault(
+      deployer,
+      assetVaultClone,
+      receipt,
+      wrapper,
+      authorizerClone,
+      dataSourceAddress,
+    );
 
     const shares = BigInt.fromString("1000000000000000000");
 
@@ -186,7 +250,7 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    depositDay100.block.timestamp = day100;
+    depositDay100.block.timestamp = BigInt.fromI32(86400 * 100);
     handleDeposit(depositDay100);
 
     const depositDay101 = createDepositEvent(
@@ -198,21 +262,60 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    depositDay101.block.timestamp = day101;
+    depositDay101.block.timestamp = BigInt.fromI32(86400 * 101);
     handleDeposit(depositDay101);
 
     assert.entityCount("VaultDayStat", 2);
 
-    const id100 = dayStatId(assetVaultClone.toHex(), day100);
-    const id101 = dayStatId(assetVaultClone.toHex(), day101);
-    assert.fieldEquals("VaultDayStat", id100, "day", day100.toString());
+    const id100 = dayStatId(
+      assetVaultClone.toHex(),
+      BigInt.fromI32(86400 * 100),
+    );
+    const id101 = dayStatId(
+      assetVaultClone.toHex(),
+      BigInt.fromI32(86400 * 101),
+    );
+    assert.fieldEquals(
+      "VaultDayStat",
+      id100,
+      "day",
+      BigInt.fromI32(86400 * 100).toString(),
+    );
     assert.fieldEquals("VaultDayStat", id100, "depositCount", "1");
-    assert.fieldEquals("VaultDayStat", id101, "day", day101.toString());
+    assert.fieldEquals(
+      "VaultDayStat",
+      id101,
+      "day",
+      BigInt.fromI32(86400 * 101).toString(),
+    );
     assert.fieldEquals("VaultDayStat", id101, "depositCount", "1");
   });
 
   test("withdraw updates withdrawCount and withdrawVolume on VaultDayStat", () => {
-    deployVault();
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+
+    deployVault(
+      deployer,
+      assetVaultClone,
+      receipt,
+      wrapper,
+      authorizerClone,
+      dataSourceAddress,
+    );
 
     const depositShares = BigInt.fromString("1000000000000000000");
     const withdrawShares = BigInt.fromString("400000000000000000");
@@ -226,7 +329,7 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    depositEvent.block.timestamp = day100;
+    depositEvent.block.timestamp = BigInt.fromI32(86400 * 100);
     handleDeposit(depositEvent);
 
     const withdrawEvent = createWithdrawEvent(
@@ -239,10 +342,10 @@ describe("VaultDayStat Test", () => {
       Bytes.fromHexString("0x"),
       assetVaultClone,
     );
-    withdrawEvent.block.timestamp = day100Noon;
+    withdrawEvent.block.timestamp = BigInt.fromI32(86400 * 100 + 3600);
     handleWithdraw(withdrawEvent);
 
-    const id = dayStatId(assetVaultClone.toHex(), day100);
+    const id = dayStatId(assetVaultClone.toHex(), BigInt.fromI32(86400 * 100));
     assert.entityCount("VaultDayStat", 1);
     assert.fieldEquals("VaultDayStat", id, "depositCount", "1");
     assert.fieldEquals("VaultDayStat", id, "withdrawCount", "1");
@@ -261,8 +364,21 @@ describe("VaultDayStat Test", () => {
   });
 
   test("wallet-to-wallet transfer increments transferCount; mint and burn do not", () => {
-    deployVault();
-
+    const deployer = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
     const sender = Address.fromString(
       "0x0000000000000000000000000000000000eeeeee",
     );
@@ -273,11 +389,20 @@ describe("VaultDayStat Test", () => {
     const amount = BigInt.fromString("1000000000000000000");
     const half = BigInt.fromString("500000000000000000");
 
+    deployVault(
+      deployer,
+      assetVaultClone,
+      receipt,
+      wrapper,
+      authorizerClone,
+      dataSourceAddress,
+    );
+
     // Mint (from zero) — must not create a VaultDayStat transfer bucket
     createMockTotalSupplyFunction(assetVaultClone, amount);
     createMockBalanceOfFunction(assetVaultClone, sender, amount);
     const mint = createTransferEvent(zero, sender, amount, assetVaultClone);
-    mint.block.timestamp = day100;
+    mint.block.timestamp = BigInt.fromI32(86400 * 100);
     handleTransfer(mint);
     assert.entityCount("VaultDayStat", 0);
 
@@ -291,10 +416,10 @@ describe("VaultDayStat Test", () => {
       half,
       assetVaultClone,
     );
-    walletTransfer.block.timestamp = day100Noon;
+    walletTransfer.block.timestamp = BigInt.fromI32(86400 * 100 + 3600);
     handleTransfer(walletTransfer);
 
-    const id = dayStatId(assetVaultClone.toHex(), day100);
+    const id = dayStatId(assetVaultClone.toHex(), BigInt.fromI32(86400 * 100));
     assert.entityCount("VaultDayStat", 1);
     assert.fieldEquals("VaultDayStat", id, "transferCount", "1");
     assert.fieldEquals("VaultDayStat", id, "depositCount", "0");
@@ -304,7 +429,7 @@ describe("VaultDayStat Test", () => {
     createMockBalanceOfFunction(assetVaultClone, recipient, ZERO);
     createMockTotalSupplyFunction(assetVaultClone, half);
     const burn = createTransferEvent(recipient, zero, half, assetVaultClone);
-    burn.block.timestamp = day100Noon;
+    burn.block.timestamp = BigInt.fromI32(86400 * 100 + 3600);
     handleTransfer(burn);
 
     assert.entityCount("VaultDayStat", 1);

--- a/tests/handleVaultDayStat.test.ts
+++ b/tests/handleVaultDayStat.test.ts
@@ -1,0 +1,313 @@
+import {
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
+} from "matchstick-as";
+import {
+  Address,
+  Bytes,
+  DataSourceContext,
+  Value,
+  BigInt,
+} from "@graphprotocol/graph-ts";
+import {
+  createDepositEvent,
+  createNewCloneEvent,
+  createMockERC20Functions,
+  createWithdrawEvent,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+  createTransferEvent,
+  createMockBalanceOfFunction,
+  createMockTotalSupplyFunction,
+} from "./mock.test";
+import { handleNewClone } from "../src/CloneFactory";
+import { handleDeployment } from "../src/StoxUnifiedDeployer";
+import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
+import {
+  handleDeposit,
+  handleWithdraw,
+  handleTransfer,
+} from "../src/OffchainAssetReceiptVault";
+import { SECONDS_PER_DAY, ZERO, ZERO_ADDRESS } from "../src/utils";
+
+function dayStart(timestamp: BigInt): BigInt {
+  return timestamp.div(SECONDS_PER_DAY).times(SECONDS_PER_DAY);
+}
+
+function dayStatId(vaultId: string, timestamp: BigInt): string {
+  return vaultId + "-" + dayStart(timestamp).toString();
+}
+
+describe("VaultDayStat Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
+  const deployer = Address.fromString(
+    "0x1234567890123456789012345678901234567890",
+  );
+  const assetVaultClone = Address.fromString(
+    "0x0000000000000000000000000000000000aaaaaa",
+  );
+  const receipt = Address.fromString(
+    "0x0000000000000000000000000000000000cccccc",
+  );
+  const wrapper = Address.fromString(
+    "0x0000000000000000000000000000000000dddddd",
+  );
+  const authorizerClone = Address.fromString(
+    "0x0000000000000000000000000000000000bbbbbb",
+  );
+
+  // UTC day 100 and day 101 midnights, plus an hour into day 100
+  const day100 = BigInt.fromI32(86400 * 100);
+  const day100Noon = day100.plus(BigInt.fromI32(3600));
+  const day101 = BigInt.fromI32(86400 * 101);
+
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
+
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
+
+  function deployVault(): void {
+    createMockReceiptFunction(assetVaultClone, receipt);
+    handleDeployment(
+      createDeploymentEvent(
+        deployer,
+        assetVaultClone,
+        wrapper,
+        Address.fromString(dataSourceAddress),
+      ),
+    );
+    handleNewClone(
+      createNewCloneEvent(
+        deployer,
+        Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS),
+        authorizerClone,
+      ),
+    );
+    createMockERC20Functions(assetVaultClone);
+  }
+
+  test("deposit creates VaultDayStat bucket with counts and volume", () => {
+    deployVault();
+
+    const shares = BigInt.fromString("1000000000000000000");
+    const depositEvent = createDepositEvent(
+      deployer,
+      deployer,
+      shares,
+      shares,
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    depositEvent.block.timestamp = day100Noon;
+    handleDeposit(depositEvent);
+
+    const id = dayStatId(assetVaultClone.toHex(), day100Noon);
+    assert.entityCount("VaultDayStat", 1);
+    assert.fieldEquals("VaultDayStat", id, "id", id);
+    assert.fieldEquals(
+      "VaultDayStat",
+      id,
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHex(),
+    );
+    assert.fieldEquals("VaultDayStat", id, "day", day100.toString());
+    assert.fieldEquals("VaultDayStat", id, "depositCount", "1");
+    assert.fieldEquals("VaultDayStat", id, "withdrawCount", "0");
+    assert.fieldEquals("VaultDayStat", id, "transferCount", "0");
+    assert.fieldEquals("VaultDayStat", id, "depositVolume", shares.toString());
+    assert.fieldEquals("VaultDayStat", id, "withdrawVolume", "0");
+  });
+
+  test("same-day deposits accumulate on one VaultDayStat", () => {
+    deployVault();
+
+    const shares1 = BigInt.fromString("1000000000000000000");
+    const shares2 = BigInt.fromString("2000000000000000000");
+
+    const deposit1 = createDepositEvent(
+      deployer,
+      deployer,
+      shares1,
+      shares1,
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    deposit1.block.timestamp = day100;
+    handleDeposit(deposit1);
+
+    const deposit2 = createDepositEvent(
+      deployer,
+      deployer,
+      shares2,
+      shares2,
+      BigInt.fromString("2"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    deposit2.block.timestamp = day100Noon;
+    handleDeposit(deposit2);
+
+    const id = dayStatId(assetVaultClone.toHex(), day100);
+    assert.entityCount("VaultDayStat", 1);
+    assert.fieldEquals("VaultDayStat", id, "depositCount", "2");
+    assert.fieldEquals(
+      "VaultDayStat",
+      id,
+      "depositVolume",
+      shares1.plus(shares2).toString(),
+    );
+  });
+
+  test("deposits on different UTC days create separate VaultDayStat rows", () => {
+    deployVault();
+
+    const shares = BigInt.fromString("1000000000000000000");
+
+    const depositDay100 = createDepositEvent(
+      deployer,
+      deployer,
+      shares,
+      shares,
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    depositDay100.block.timestamp = day100;
+    handleDeposit(depositDay100);
+
+    const depositDay101 = createDepositEvent(
+      deployer,
+      deployer,
+      shares,
+      shares,
+      BigInt.fromString("2"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    depositDay101.block.timestamp = day101;
+    handleDeposit(depositDay101);
+
+    assert.entityCount("VaultDayStat", 2);
+
+    const id100 = dayStatId(assetVaultClone.toHex(), day100);
+    const id101 = dayStatId(assetVaultClone.toHex(), day101);
+    assert.fieldEquals("VaultDayStat", id100, "day", day100.toString());
+    assert.fieldEquals("VaultDayStat", id100, "depositCount", "1");
+    assert.fieldEquals("VaultDayStat", id101, "day", day101.toString());
+    assert.fieldEquals("VaultDayStat", id101, "depositCount", "1");
+  });
+
+  test("withdraw updates withdrawCount and withdrawVolume on VaultDayStat", () => {
+    deployVault();
+
+    const depositShares = BigInt.fromString("1000000000000000000");
+    const withdrawShares = BigInt.fromString("400000000000000000");
+
+    const depositEvent = createDepositEvent(
+      deployer,
+      deployer,
+      depositShares,
+      depositShares,
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    depositEvent.block.timestamp = day100;
+    handleDeposit(depositEvent);
+
+    const withdrawEvent = createWithdrawEvent(
+      deployer,
+      deployer,
+      deployer,
+      withdrawShares,
+      withdrawShares,
+      BigInt.fromString("1"),
+      Bytes.fromHexString("0x"),
+      assetVaultClone,
+    );
+    withdrawEvent.block.timestamp = day100Noon;
+    handleWithdraw(withdrawEvent);
+
+    const id = dayStatId(assetVaultClone.toHex(), day100);
+    assert.entityCount("VaultDayStat", 1);
+    assert.fieldEquals("VaultDayStat", id, "depositCount", "1");
+    assert.fieldEquals("VaultDayStat", id, "withdrawCount", "1");
+    assert.fieldEquals(
+      "VaultDayStat",
+      id,
+      "depositVolume",
+      depositShares.toString(),
+    );
+    assert.fieldEquals(
+      "VaultDayStat",
+      id,
+      "withdrawVolume",
+      withdrawShares.toString(),
+    );
+  });
+
+  test("wallet-to-wallet transfer increments transferCount; mint and burn do not", () => {
+    deployVault();
+
+    const sender = Address.fromString(
+      "0x0000000000000000000000000000000000eeeeee",
+    );
+    const recipient = Address.fromString(
+      "0x0000000000000000000000000000000000ffffff",
+    );
+    const zero = Address.fromString(ZERO_ADDRESS);
+    const amount = BigInt.fromString("1000000000000000000");
+    const half = BigInt.fromString("500000000000000000");
+
+    // Mint (from zero) — must not create a VaultDayStat transfer bucket
+    createMockTotalSupplyFunction(assetVaultClone, amount);
+    createMockBalanceOfFunction(assetVaultClone, sender, amount);
+    const mint = createTransferEvent(zero, sender, amount, assetVaultClone);
+    mint.block.timestamp = day100;
+    handleTransfer(mint);
+    assert.entityCount("VaultDayStat", 0);
+
+    // Wallet-to-wallet — creates day stat with transferCount=1
+    createMockBalanceOfFunction(assetVaultClone, sender, half);
+    createMockBalanceOfFunction(assetVaultClone, recipient, half);
+    createMockTotalSupplyFunction(assetVaultClone, amount);
+    const walletTransfer = createTransferEvent(
+      sender,
+      recipient,
+      half,
+      assetVaultClone,
+    );
+    walletTransfer.block.timestamp = day100Noon;
+    handleTransfer(walletTransfer);
+
+    const id = dayStatId(assetVaultClone.toHex(), day100);
+    assert.entityCount("VaultDayStat", 1);
+    assert.fieldEquals("VaultDayStat", id, "transferCount", "1");
+    assert.fieldEquals("VaultDayStat", id, "depositCount", "0");
+    assert.fieldEquals("VaultDayStat", id, "withdrawCount", "0");
+
+    // Burn (to zero) — must not bump transferCount
+    createMockBalanceOfFunction(assetVaultClone, recipient, ZERO);
+    createMockTotalSupplyFunction(assetVaultClone, half);
+    const burn = createTransferEvent(recipient, zero, half, assetVaultClone);
+    burn.block.timestamp = day100Noon;
+    handleTransfer(burn);
+
+    assert.entityCount("VaultDayStat", 1);
+    assert.fieldEquals("VaultDayStat", id, "transferCount", "1");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `VaultDayStat` entity (`{vault}-{utcMidnight}`) with deposit/withdraw/transfer counts and volumes
- Update deposit, withdraw, and share-transfer handlers to maintain day buckets incrementally
- Exclude mint/burn share transfers from `transferCount` (wallet-to-wallet only)
- Add Matchstick coverage in `tests/handleVaultDayStat.test.ts`

## Test plan
- [x] CI Matchstick suite passes
- [ ] Query `vaultDayStats` after re-index and confirm day buckets match deposit/withdraw/transfer activity
- [ ] Confirm mint/burn transfers do not inflate `transferCount`


Made with [Cursor](https://cursor.com)