### PR TITLE
Align deploy Nix cache with raindex to avoid post-job cancels

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,19 +21,41 @@ on:
           - songbird
           - linea
       version:
-        description: "Goldsky subgraph version (e.g. 1.0.13). Current base is 1.0.12 — bump when deploying."
+        description: "Goldsky subgraph version (e.g. 1.0.14). Current base is 1.0.13 — bump when deploying."
         required: true
         type: string
 jobs:
   deploy:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      # Align with raindex deploy-subgraph: avoid Determinate magic-nix-cache post
+      # uploads that can cancel the job after a successful Goldsky deploy.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
       - run: nix develop -c rainix-sol-prelude
       - run: ./prep-ethgild.sh
       - run: nix develop -c graph codegen

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ The workflow will:
 1. Build contract artifacts and the subgraph
 2. Deploy to Goldsky as `sft-<network>/<version>`
 
-Bump the version for each new deploy of a network (current `base` is `1.0.12`).
+Bump the version for each new deploy of a network (current `base` is `1.0.13`).
 Reusing an existing version name will fail or overwrite depending on Goldsky
 behavior — prefer always bumping.
 
-Requires the `CI_GOLDSKY_TOKEN` repository secret.
+Requires the `CI_GOLDSKY_TOKEN` repository secret. Optional `CACHIX_AUTH_TOKEN`
+speeds up Nix restores via the public `rainlanguage` Cachix (deploy still works
+without it).
 
 Supported networks: `arbitrum-one`, `arbitrum_sepolia`, `avalanche`, `base`,
 `bsc`, `mainnet`, `flare`, `mumbai`, `oasis_sapphire`, `matic`, `sepolia`,


### PR DESCRIPTION
## Summary
- Drop `DeterminateSystems/magic-nix-cache-action` (post-upload cancel was failing the job after a successful `sft-base/1.0.13` deploy)
- Match [raindex deploy-subgraph](https://github.com/rainlanguage/raindex/blob/main/.github/workflows/deploy-subgraph.yaml): free disk space, `nix-quick-install`, Cachix (`continue-on-error`), `cache-nix-action` with 1G store cap
- Keep network/version inputs and Goldsky deploy steps unchanged
- Note optional `CACHIX_AUTH_TOKEN` in the README; bump documented base version to `1.0.13`

## Test plan
- [ ] Trigger **Deploy subgraph** on `base` with a new version (e.g. `1.0.14`)
- [ ] Confirm Goldsky deploy succeeds and the workflow stays green through job completion
- [ ] Confirm missing `CACHIX_AUTH_TOKEN` does not fail the job (`continue-on-error`)


Made with [Cursor](https://cursor.com)