### PR TITLE
Index alternate CloneFactory and create authorizers on AuthorizerSet

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -1,13 +1,16 @@
 {
-    "base": {
-        "CloneFactory": {
-            "address": "0x5e9e22154D71f9Fd4b5FD1eE36852A4c9FcDcC9E",
-            "startBlock": 39975787
-        },
-        "StoxUnifiedDeployer": {
-            "address": "0x821a71a313bdDDc94192CF0b5F6f5bC31Ac75853",
-            "startBlock": 41197252
-        }
+  "base": {
+    "CloneFactory": {
+      "address": "0x5e9e22154D71f9Fd4b5FD1eE36852A4c9FcDcC9E",
+      "startBlock": 39975787
+    },
+    "CloneFactoryAlt": {
+      "address": "0x444acC29d63fa643E8adCC35FD9aa6DE111dCb39",
+      "startBlock": 41974475
+    },
+    "StoxUnifiedDeployer": {
+      "address": "0x821a71a313bdDDc94192CF0b5F6f5bC31Ac75853",
+      "startBlock": 41197252
     }
-    
+  }
 }

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -20,7 +20,10 @@ import {
   Account,
   Authorizer,
 } from "../generated/schema";
-import { ReceiptTemplate } from "../generated/templates";
+import {
+  ReceiptTemplate,
+  OffchainAssetReceiptVaultAuthorizerV1Template,
+} from "../generated/templates";
 import {
   Certify as CertifyEvent,
   ConfiscateShares as ConfiscateSharesEvent,
@@ -51,35 +54,53 @@ import { store, Entity, Value } from "@graphprotocol/graph-ts";
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { CBORDecoder } from "@rainprotocol/assemblyscript-cbor";
 
+/**
+ * Get or create an Authorizer entity. Shared / alternate-factory authorizers are
+ * often set on a vault without a prior NewClone from the indexed CloneFactory.
+ */
+function getOrCreateAuthorizer(authorizerAddress: Address): Authorizer {
+  let id = authorizerAddress.toHex();
+  let authorizer = Authorizer.load(id);
+  if (!authorizer) {
+    authorizer = new Authorizer(id);
+    authorizer.address = authorizerAddress;
+    authorizer.isActive = false;
+  }
+  return authorizer as Authorizer;
+}
+
 export function handleAuthorizerSet(event: AuthorizerSet): void {
   let offchainAssetReceiptVault = OffchainAssetReceiptVault.load(
     event.address.toHex(),
   );
-  if (offchainAssetReceiptVault) {
-    if (offchainAssetReceiptVault.activeAuthorizer != null) {
-      let previousAuthorizer = Authorizer.load(
-        offchainAssetReceiptVault.activeAuthorizer as string,
-      );
-      if (
-        previousAuthorizer &&
-        previousAuthorizer.id != event.params.authorizer.toHex()
-      ) {
-        previousAuthorizer.isActive = false;
-        previousAuthorizer.save();
-      }
-    }
+  if (!offchainAssetReceiptVault) {
+    return;
+  }
 
-    let authorizer = Authorizer.load(event.params.authorizer.toHex());
-    if (authorizer) {
-      authorizer.isActive = true;
-      authorizer.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
-      authorizer.save();
-
-      // Set Active Authorizer
-      offchainAssetReceiptVault.activeAuthorizer = authorizer.id;
-      offchainAssetReceiptVault.save();
+  if (offchainAssetReceiptVault.activeAuthorizer != null) {
+    let previousAuthorizer = Authorizer.load(
+      offchainAssetReceiptVault.activeAuthorizer as string,
+    );
+    if (
+      previousAuthorizer &&
+      previousAuthorizer.id != event.params.authorizer.toHex()
+    ) {
+      previousAuthorizer.isActive = false;
+      previousAuthorizer.save();
     }
   }
+
+  let authorizer = getOrCreateAuthorizer(event.params.authorizer);
+  authorizer.isActive = true;
+  authorizer.offchainAssetReceiptVault = offchainAssetReceiptVault.id;
+  authorizer.save();
+
+  // Ensure RoleGranted/RoleRevoked are indexed even when NewClone was missed
+  // (unknown factory / unknown implementation). Idempotent if already created.
+  OffchainAssetReceiptVaultAuthorizerV1Template.create(event.params.authorizer);
+
+  offchainAssetReceiptVault.activeAuthorizer = authorizer.id;
+  offchainAssetReceiptVault.save();
 }
 
 export function handleCertify(event: CertifyEvent): void {

--- a/src/networkImplementation.ts
+++ b/src/networkImplementation.ts
@@ -1,92 +1,95 @@
 // Authorizer Implementation Addresses
-export const AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0x99B2aC726f8e41a22f27e7e35D554888103b88E9";
-export const ARBITRUM_ONE_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0x0438560b398eA874DEb29360aCda10735D9790C8";
-export const BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0x2B4A510c3619d5E888095BFE9f95902D32dA5556";
-export const BASE_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0xfDd9F4Cd3Db08c2a8cCa9CE181710a69de7d6c87";
-export const BASE_SEPOLIA_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0x667d2Ab75908c7d7983008aDbF558332F381a5f5";
-export const BASE_SEPOLIA_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0x72b2a394E129ede556b4024aCe939a964bA0a876";
-export const POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
-export const MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
-
+export const AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0x99B2aC726f8e41a22f27e7e35D554888103b88E9";
+export const ARBITRUM_ONE_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0x0438560b398eA874DEb29360aCda10735D9790C8";
+export const BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0x2B4A510c3619d5E888095BFE9f95902D32dA5556";
+export const BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS_ALT =
+  "0x2EA0d35d0B1F57C42e6130f298930228bCbFDe9b";
+export const BASE_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0xfDd9F4Cd3Db08c2a8cCa9CE181710a69de7d6c87";
+export const BASE_SEPOLIA_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0x667d2Ab75908c7d7983008aDbF558332F381a5f5";
+export const BASE_SEPOLIA_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0x72b2a394E129ede556b4024aCe939a964bA0a876";
+export const POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
+export const MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
 
 // Vault Implementation Addresses
 // Disable all vault implementations, vault implementations handled by OffchainAssetReceiptVaultBeaconSetDeployer
-export const AMOY_VAULT_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
-export const ARBITRUM_ONE_VAULT_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
-export const BASE_VAULT_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
-export const POLYGON_VAULT_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
-export const MAINNET_VAULT_IMPLEMENTATION_ADDRESS = "0xffffffffffffffffffffffffffffffffffffffff";
+export const AMOY_VAULT_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
+export const ARBITRUM_ONE_VAULT_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
+export const BASE_VAULT_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
+export const POLYGON_VAULT_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
+export const MAINNET_VAULT_IMPLEMENTATION_ADDRESS =
+  "0xffffffffffffffffffffffffffffffffffffffff";
 
 export class NetworkImplementation {
   // Authorizer implementation addresses by network
   public authorizerImplementations: string[];
-  
+
   // Vault implementation addresses by network
   public vaultImplementations: string[];
-  
+
   constructor(network: string) {
     this.authorizerImplementations = [];
     this.vaultImplementations = [];
-  
-    if (network == 'mainnet') {
+
+    if (network == "mainnet") {
       this.authorizerImplementations = [
-        MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS 
+        MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [
-        MAINNET_VAULT_IMPLEMENTATION_ADDRESS
-      ];
-    } else if (network == 'polygon') {
+      this.vaultImplementations = [MAINNET_VAULT_IMPLEMENTATION_ADDRESS];
+    } else if (network == "polygon") {
       this.authorizerImplementations = [
-        POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS
+        POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [
-        POLYGON_VAULT_IMPLEMENTATION_ADDRESS
-      ];
-    } else if (network == 'arbitrum-one') {
+      this.vaultImplementations = [POLYGON_VAULT_IMPLEMENTATION_ADDRESS];
+    } else if (network == "arbitrum-one") {
       this.authorizerImplementations = [
-        ARBITRUM_ONE_AUTHORIZER_IMPLEMENTATION_ADDRESS
+        ARBITRUM_ONE_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [
-        ARBITRUM_ONE_VAULT_IMPLEMENTATION_ADDRESS
-      ];
-    } else if (network == 'polygon-amoy') {
-      this.authorizerImplementations = [
-        AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS
-      ];
-      this.vaultImplementations = [
-        AMOY_VAULT_IMPLEMENTATION_ADDRESS
-      ];
-    } else if (network == 'base') {
+      this.vaultImplementations = [ARBITRUM_ONE_VAULT_IMPLEMENTATION_ADDRESS];
+    } else if (network == "polygon-amoy") {
+      this.authorizerImplementations = [AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS];
+      this.vaultImplementations = [AMOY_VAULT_IMPLEMENTATION_ADDRESS];
+    } else if (network == "base") {
       this.authorizerImplementations = [
         BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS,
-        BASE_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS
+        BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS_ALT,
+        BASE_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [
-        BASE_VAULT_IMPLEMENTATION_ADDRESS
-      ];
-    } else if (network == 'base-sepolia') {
+      this.vaultImplementations = [BASE_VAULT_IMPLEMENTATION_ADDRESS];
+    } else if (network == "base-sepolia") {
       this.authorizerImplementations = [
         BASE_SEPOLIA_AUTHORIZER_IMPLEMENTATION_ADDRESS,
-        BASE_SEPOLIA_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS
+        BASE_SEPOLIA_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [
-        BASE_VAULT_IMPLEMENTATION_ADDRESS
-      ];
+      this.vaultImplementations = [BASE_VAULT_IMPLEMENTATION_ADDRESS];
     } else {
       this.authorizerImplementations = [];
       this.vaultImplementations = [];
     }
   }
-  
+
   public isAuthorizerImplementation(address: string): boolean {
     for (let i = 0; i < this.authorizerImplementations.length; i++) {
-      if (address.toLowerCase() == this.authorizerImplementations[i].toLowerCase()) {
+      if (
+        address.toLowerCase() == this.authorizerImplementations[i].toLowerCase()
+      ) {
         return true;
       }
     }
     return address.includes("Authorizer") || address.includes("authorizer");
   }
-  
+
   public isVaultImplementation(address: string): boolean {
     for (let i = 0; i < this.vaultImplementations.length; i++) {
       if (address.toLowerCase() == this.vaultImplementations[i].toLowerCase()) {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -23,6 +23,28 @@ dataSources:
         - event: NewClone(address,address,address)
           handler: handleNewClone
       file: ./src/CloneFactory.ts
+  # Alternate Rain CloneFactory used by some Base authorizer deployments
+  # (e.g. shared authorizer 0x315b16… cloned via this factory).
+  - kind: ethereum/contract
+    name: CloneFactoryAlt
+    network: base
+    source:
+      abi: CloneFactory
+      address: "0x444acC29d63fa643E8adCC35FD9aa6DE111dCb39"
+      startBlock: 41974475
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Authorizer
+      abis:
+        - name: CloneFactory
+          file: ./lib/rain.factory/out/CloneFactory.sol/CloneFactory.json
+      eventHandlers:
+        - event: NewClone(address,address,address)
+          handler: handleNewClone
+      file: ./src/CloneFactory.ts
   - kind: ethereum/contract
     name: StoxUnifiedDeployer
     network: base

--- a/tests/handleSetAuthorizer.test.ts
+++ b/tests/handleSetAuthorizer.test.ts
@@ -1,20 +1,21 @@
 import {
-    test,
-    assert,
-    clearStore,
-    describe,
-    afterEach,
-    beforeAll,
-    clearInBlockStore,
-    dataSourceMock,
-    logStore
+  test,
+  assert,
+  clearStore,
+  describe,
+  afterEach,
+  beforeAll,
+  clearInBlockStore,
+  dataSourceMock,
+  logStore,
 } from "matchstick-as";
+import { Address, DataSourceContext, Value } from "@graphprotocol/graph-ts";
 import {
-    Address,
-    DataSourceContext,
-    Value
-} from "@graphprotocol/graph-ts";
-import { createNewCloneEvent, createSetAuthorizerEvent, createDeploymentEvent, createMockReceiptFunction } from "./mock.test";
+  createNewCloneEvent,
+  createSetAuthorizerEvent,
+  createDeploymentEvent,
+  createMockReceiptFunction,
+} from "./mock.test";
 import { handleNewClone } from "../src/CloneFactory";
 import { handleDeployment } from "../src/StoxUnifiedDeployer";
 import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
@@ -22,145 +23,264 @@ import { handleAuthorizerSet } from "../src/OffchainAssetReceiptVault";
 import { Authorizer } from "../generated/schema";
 
 describe("Set Authorizer Test", () => {
+  const dataSourceAddress = "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A";
 
-    const dataSourceAddress = '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A';
+  beforeAll(() => {
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(dataSourceAddress, "polygon-amoy", context);
+  });
 
-    beforeAll(() => {
-        let context = new DataSourceContext()
-        context.set('contextVal', Value.fromI32(325))
-        dataSourceMock.setReturnValues(dataSourceAddress, 'polygon-amoy', context)
-    });
+  afterEach(() => {
+    clearStore();
+    clearInBlockStore();
+  });
 
-    afterEach(() => {
-        clearStore();
-        clearInBlockStore();
-    });
+  test("handle set authorizer", () => {
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
 
-    test("handle set authorizer", () => {
-        const sender = Address.fromString("0x1234567890123456789012345678901234567890");
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone = Address.fromString(
+      "0x0000000000000000000000000000000000000aaa",
+    );
+    let authorizerCloneEvent = createNewCloneEvent(
+      sender,
+      authorizerImplementation,
+      authorizerClone,
+    );
+    handleNewClone(authorizerCloneEvent);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone = Address.fromString("0x0000000000000000000000000000000000000aaa");
-        let authorizerCloneEvent = createNewCloneEvent(sender, authorizerImplementation, authorizerClone);
-        handleNewClone(authorizerCloneEvent);
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000000bbb",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000000ccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000000ddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      sender,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000000bbb");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000000ccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000000ddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(sender, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2);
+    assert.fieldEquals(
+      "Authorizer",
+      assetVaultClone.toHexString(),
+      "isActive",
+      "true",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHexString(),
+      "activeAuthorizer",
+      assetVaultClone.toHexString(),
+    );
 
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 2);
-        assert.fieldEquals(
-            "Authorizer",
-            assetVaultClone.toHexString(),
-            "isActive",
-            "true"
-        );
-        assert.fieldEquals(
-            "OffchainAssetReceiptVault",
-            assetVaultClone.toHexString(),
-            "activeAuthorizer",
-            assetVaultClone.toHexString()
-        );
+    // Set Authorizer
+    const authorizerSetEvent = createSetAuthorizerEvent(
+      sender,
+      authorizerClone,
+      assetVaultClone,
+    );
+    handleAuthorizerSet(authorizerSetEvent);
+    assert.fieldEquals(
+      "Authorizer",
+      authorizerClone.toHexString(),
+      "isActive",
+      "true",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHexString(),
+      "activeAuthorizer",
+      authorizerClone.toHexString(),
+    );
+    let assetVaultAuthorizer = Authorizer.load(assetVaultClone.toHexString());
+    assert.assertNotNull(assetVaultAuthorizer);
+    if (assetVaultAuthorizer == null) {
+      return;
+    }
+    assert.booleanEquals(assetVaultAuthorizer.isActive, false);
+  });
 
-        // Set Authorizer
-        const authorizerSetEvent = createSetAuthorizerEvent(sender, authorizerClone, assetVaultClone);
-        handleAuthorizerSet(authorizerSetEvent);
-        assert.fieldEquals(
-            "Authorizer",
-            authorizerClone.toHexString(),
-            "isActive",
-            "true"
-        );
-        assert.fieldEquals(
-            "OffchainAssetReceiptVault",
-            assetVaultClone.toHexString(),
-            "activeAuthorizer",
-            authorizerClone.toHexString()
-        );
-        let assetVaultAuthorizer = Authorizer.load(assetVaultClone.toHexString());
-        assert.assertNotNull(assetVaultAuthorizer);
-        if (assetVaultAuthorizer == null) {
-            return;
-        }
-        assert.booleanEquals(assetVaultAuthorizer.isActive, false);
-        
-    });
+  test("handle set authorizer with multiple authorizers", () => {
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
 
-    test("handle set authorizer with multiple authorizers", () => {
-        const sender = Address.fromString("0x1234567890123456789012345678901234567890");
+    // Asset Vault Deployment (handled by StoxUnifiedDeployer)
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000aaaaaa",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000dddddd",
+    );
+    // Mock the receipt() RPC call
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      sender,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
 
-        // Asset Vault Deployment (handled by StoxUnifiedDeployer)
-        const assetVaultClone = Address.fromString("0x0000000000000000000000000000000000aaaaaa");
-        const receipt = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        const wrapper = Address.fromString("0x0000000000000000000000000000000000dddddd");
-        // Mock the receipt() RPC call
-        createMockReceiptFunction(assetVaultClone, receipt);
-        let deploymentEvent = createDeploymentEvent(sender, assetVaultClone, wrapper, Address.fromString(dataSourceAddress));
-        handleDeployment(deploymentEvent);
+    // Authorizer Clone
+    const authorizerImplementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const authorizerClone1 = Address.fromString(
+      "0x0000000000000000000000000000000000bbbbbb",
+    );
+    let authorizerCloneEvent1 = createNewCloneEvent(
+      sender,
+      authorizerImplementation,
+      authorizerClone1,
+    );
+    handleNewClone(authorizerCloneEvent1);
 
-        // Authorizer Clone
-        const authorizerImplementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-        const authorizerClone1 = Address.fromString("0x0000000000000000000000000000000000bbbbbb");
-        let authorizerCloneEvent1 = createNewCloneEvent(sender, authorizerImplementation, authorizerClone1);
-        handleNewClone(authorizerCloneEvent1);
+    // Set Authorizer
+    const authorizerSetEvent1 = createSetAuthorizerEvent(
+      sender,
+      authorizerClone1,
+      assetVaultClone,
+    );
+    handleAuthorizerSet(authorizerSetEvent1);
 
-        // Set Authorizer
-        const authorizerSetEvent1 = createSetAuthorizerEvent(sender, authorizerClone1, assetVaultClone);
-        handleAuthorizerSet(authorizerSetEvent1);
+    // Assertions
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2);
+    assert.fieldEquals(
+      "Authorizer",
+      authorizerClone1.toHexString(),
+      "isActive",
+      "true",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHexString(),
+      "activeAuthorizer",
+      authorizerClone1.toHexString(),
+    );
 
-        // Assertions
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 2);
-        assert.fieldEquals(
-            "Authorizer",
-            authorizerClone1.toHexString(),
-            "isActive",
-            "true"
-        );
-        assert.fieldEquals(
-            "OffchainAssetReceiptVault",
-            assetVaultClone.toHexString(),
-            "activeAuthorizer",
-            authorizerClone1.toHexString()
-        );
-        
-        const authorizerClone2 = Address.fromString("0x0000000000000000000000000000000000cccccc");
-        let authorizerCloneEvent2 = createNewCloneEvent(sender, authorizerImplementation, authorizerClone2);
-        handleNewClone(authorizerCloneEvent2);
+    const authorizerClone2 = Address.fromString(
+      "0x0000000000000000000000000000000000cccccc",
+    );
+    let authorizerCloneEvent2 = createNewCloneEvent(
+      sender,
+      authorizerImplementation,
+      authorizerClone2,
+    );
+    handleNewClone(authorizerCloneEvent2);
 
-        const authorizerSetEvent2 = createSetAuthorizerEvent(sender, authorizerClone2, assetVaultClone);
-        handleAuthorizerSet(authorizerSetEvent2);
+    const authorizerSetEvent2 = createSetAuthorizerEvent(
+      sender,
+      authorizerClone2,
+      assetVaultClone,
+    );
+    handleAuthorizerSet(authorizerSetEvent2);
 
-        // Assertions
-        assert.entityCount("OffchainAssetReceiptVault", 1);
-        assert.entityCount("Authorizer", 3);
+    // Assertions
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 3);
 
-        assert.fieldEquals(
-            "Authorizer",
-            authorizerClone1.toHexString(),
-            "isActive",
-            "false"
-        );
-        assert.fieldEquals(
-            "Authorizer",
-            authorizerClone2.toHexString(),
-            "isActive",
-            "true"
-        );
-        assert.fieldEquals(
-            "OffchainAssetReceiptVault",
-            assetVaultClone.toHexString(),
-            "activeAuthorizer",
-            authorizerClone2.toHexString()
-        );
-        
-    });
-    
-})
+    assert.fieldEquals(
+      "Authorizer",
+      authorizerClone1.toHexString(),
+      "isActive",
+      "false",
+    );
+    assert.fieldEquals(
+      "Authorizer",
+      authorizerClone2.toHexString(),
+      "isActive",
+      "true",
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHexString(),
+      "activeAuthorizer",
+      authorizerClone2.toHexString(),
+    );
+  });
+
+  test("handle set authorizer without prior NewClone creates authorizer", () => {
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+
+    const assetVaultClone = Address.fromString(
+      "0x0000000000000000000000000000000000eeeeee",
+    );
+    const receipt = Address.fromString(
+      "0x0000000000000000000000000000000000ffffff",
+    );
+    const wrapper = Address.fromString(
+      "0x0000000000000000000000000000000000111111",
+    );
+    createMockReceiptFunction(assetVaultClone, receipt);
+    let deploymentEvent = createDeploymentEvent(
+      sender,
+      assetVaultClone,
+      wrapper,
+      Address.fromString(dataSourceAddress),
+    );
+    handleDeployment(deploymentEvent);
+
+    // Shared / alternate-factory authorizer — never seen via NewClone
+    const sharedAuthorizer = Address.fromString(
+      "0x0000000000000000000000000000000000315b16",
+    );
+    const authorizerSetEvent = createSetAuthorizerEvent(
+      sender,
+      sharedAuthorizer,
+      assetVaultClone,
+    );
+    handleAuthorizerSet(authorizerSetEvent);
+
+    assert.entityCount("OffchainAssetReceiptVault", 1);
+    assert.entityCount("Authorizer", 2);
+    assert.fieldEquals(
+      "Authorizer",
+      sharedAuthorizer.toHexString(),
+      "isActive",
+      "true",
+    );
+    assert.fieldEquals(
+      "Authorizer",
+      sharedAuthorizer.toHexString(),
+      "offchainAssetReceiptVault",
+      assetVaultClone.toHexString(),
+    );
+    assert.fieldEquals(
+      "OffchainAssetReceiptVault",
+      assetVaultClone.toHexString(),
+      "activeAuthorizer",
+      sharedAuthorizer.toHexString(),
+    );
+
+    let stubAuthorizer = Authorizer.load(assetVaultClone.toHexString());
+    assert.assertNotNull(stubAuthorizer);
+    if (stubAuthorizer == null) {
+      return;
+    }
+    assert.booleanEquals(stubAuthorizer.isActive, false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Base `CloneFactoryAlt` data source (`0x444acC…` / start block `41974475`) in `subgraph.yaml` and `networks.json`
- Register `BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS_ALT` for clone recognition
- On `AuthorizerSet`, get-or-create the `Authorizer` entity and start the authorizer template so shared / alternate-factory authorizers are indexed without a prior `NewClone`
- Cover the missing-`NewClone` path in Matchstick

## Test plan
- [x] CI Matchstick suite passes
- [ ] After re-index on Base, vaults that use the alt factory / shared authorizer expose an active `Authorizer` and role events


Made with [Cursor](https://cursor.com)