### PR TITLE
Add Ethereum mainnet network config

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -12,5 +12,19 @@
       "address": "0x821a71a313bdDDc94192CF0b5F6f5bC31Ac75853",
       "startBlock": 41197252
     }
+  },
+  "mainnet": {
+    "CloneFactory": {
+      "address": "0x444acC29d63fa643E8adCC35FD9aa6DE111dCb39",
+      "startBlock": 25587060
+    },
+    "CloneFactoryAlt": {
+      "address": "0x444acC29d63fa643E8adCC35FD9aa6DE111dCb39",
+      "startBlock": 99999999
+    },
+    "StoxUnifiedDeployer": {
+      "address": "0x81D0ecD58346bf2d484E7774f55EABc1AA3F4bcc",
+      "startBlock": 25546009
+    }
   }
 }

--- a/src/networkImplementation.ts
+++ b/src/networkImplementation.ts
@@ -16,7 +16,7 @@ export const BASE_SEPOLIA_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS =
 export const POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS =
   "0xffffffffffffffffffffffffffffffffffffffff";
 export const MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS =
-  "0xffffffffffffffffffffffffffffffffffffffff";
+  "0x2EA0d35d0B1F57C42e6130f298930228bCbFDe9b";
 
 // Vault Implementation Addresses
 // Disable all vault implementations, vault implementations handled by OffchainAssetReceiptVaultBeaconSetDeployer


### PR DESCRIPTION
## Summary
- Add `mainnet` entries to `networks.json`:
  - CloneFactory [`0x444acC…`](https://etherscan.io/address/0x444acC29d63fa643E8adCC35FD9aa6DE111dCb39) @ block `25587060`
  - StoxUnifiedDeployer [`0x81D0ec…`](https://etherscan.io/address/0x81D0ecD58346bf2d484E7774f55EABc1AA3F4bcc) @ block `25546009`
  - `CloneFactoryAlt` disabled via far-future start block (no second factory on mainnet; avoids double-indexing the same factory)
- Set `MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS` to [`0x2EA0d3…`](https://etherscan.io/address/0x2EA0d35d0B1F57C42e6130f298930228bCbFDe9b)

## Deploy
After merge, run **Deploy subgraph** with:
- network: `mainnet`
- version: e.g. `1.0.0`

## Test plan
- [x] `graph build --network mainnet`
- [x] Manual Goldsky deploy `sft-mainnet/<version>`
- [x] Confirm vault Deployments and authorizer NewClones appear after sync


Made with [Cursor](https://cursor.com)