### PR TITLE
Add mainnet payment mint authorizer implementation

### DIFF
--- a/src/CloneFactory.ts
+++ b/src/CloneFactory.ts
@@ -1,28 +1,20 @@
-import {
-  NewClone,
-} from "../generated/CloneFactory/CloneFactory";
-import {
-  Authorizer,
-  Deployer,
-  OffchainAssetReceiptVault
-} from "../generated/schema";
-import { OffchainAssetReceiptVaultTemplate, OffchainAssetReceiptVaultAuthorizerV1Template } from "../generated/templates";
-import { ZERO, ZERO_ADDRESS } from "./utils";
+import { NewClone } from "../generated/CloneFactory/CloneFactory";
+import { Authorizer } from "../generated/schema";
+import { OffchainAssetReceiptVaultAuthorizerV1Template } from "../generated/templates";
 import { NetworkImplementation } from "./networkImplementation";
 import { dataSource } from "@graphprotocol/graph-ts";
 
-export function handleNewClone(event: NewClone): void {  
+export function handleNewClone(event: NewClone): void {
   let implementationAddress = event.params.implementation.toHex();
 
   let networkImplementation = new NetworkImplementation(dataSource.network());
-  
+
   if (networkImplementation.isAuthorizerImplementation(implementationAddress)) {
-    // Handle as an authorizer
     let authorizer = new Authorizer(event.params.clone.toHex());
     authorizer.address = event.params.clone;
     authorizer.isActive = true;
     authorizer.save();
-  
+
     OffchainAssetReceiptVaultAuthorizerV1Template.create(event.params.clone);
   }
 }

--- a/src/OffchainAssetReceiptVault.ts
+++ b/src/OffchainAssetReceiptVault.ts
@@ -17,7 +17,6 @@ import {
   TokenHolder,
   SharesTransfer,
   SharesBalance,
-  Account,
   Authorizer,
 } from "../generated/schema";
 import {
@@ -50,7 +49,6 @@ import {
   BigintToHexString,
   ZERO_ADDRESS,
 } from "./utils";
-import { store, Entity, Value } from "@graphprotocol/graph-ts";
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { CBORDecoder } from "@rainprotocol/assemblyscript-cbor";
 

--- a/src/networkImplementation.ts
+++ b/src/networkImplementation.ts
@@ -20,65 +20,42 @@ export const MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS =
 export const MAINNET_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS =
   "0xeaD68E489Cb19453b294dc46a3A5710b0d46d17F";
 
-// Vault Implementation Addresses
-// Disable all vault implementations, vault implementations handled by OffchainAssetReceiptVaultBeaconSetDeployer
-export const AMOY_VAULT_IMPLEMENTATION_ADDRESS =
-  "0xffffffffffffffffffffffffffffffffffffffff";
-export const ARBITRUM_ONE_VAULT_IMPLEMENTATION_ADDRESS =
-  "0xffffffffffffffffffffffffffffffffffffffff";
-export const BASE_VAULT_IMPLEMENTATION_ADDRESS =
-  "0xffffffffffffffffffffffffffffffffffffffff";
-export const POLYGON_VAULT_IMPLEMENTATION_ADDRESS =
-  "0xffffffffffffffffffffffffffffffffffffffff";
-export const MAINNET_VAULT_IMPLEMENTATION_ADDRESS =
-  "0xffffffffffffffffffffffffffffffffffffffff";
-
+/**
+ * Known authorizer implementation addresses per network.
+ * Vault clones are not created via CloneFactory — they come from StoxUnifiedDeployer.
+ */
 export class NetworkImplementation {
-  // Authorizer implementation addresses by network
   public authorizerImplementations: string[];
-
-  // Vault implementation addresses by network
-  public vaultImplementations: string[];
 
   constructor(network: string) {
     this.authorizerImplementations = [];
-    this.vaultImplementations = [];
 
     if (network == "mainnet") {
       this.authorizerImplementations = [
         MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS,
         MAINNET_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [MAINNET_VAULT_IMPLEMENTATION_ADDRESS];
     } else if (network == "polygon") {
       this.authorizerImplementations = [
         POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [POLYGON_VAULT_IMPLEMENTATION_ADDRESS];
     } else if (network == "arbitrum-one") {
       this.authorizerImplementations = [
         ARBITRUM_ONE_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [ARBITRUM_ONE_VAULT_IMPLEMENTATION_ADDRESS];
     } else if (network == "polygon-amoy") {
       this.authorizerImplementations = [AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS];
-      this.vaultImplementations = [AMOY_VAULT_IMPLEMENTATION_ADDRESS];
     } else if (network == "base") {
       this.authorizerImplementations = [
         BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS,
         BASE_AUTHORIZER_IMPLEMENTATION_ADDRESS_ALT,
         BASE_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [BASE_VAULT_IMPLEMENTATION_ADDRESS];
     } else if (network == "base-sepolia") {
       this.authorizerImplementations = [
         BASE_SEPOLIA_AUTHORIZER_IMPLEMENTATION_ADDRESS,
         BASE_SEPOLIA_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
-      this.vaultImplementations = [BASE_VAULT_IMPLEMENTATION_ADDRESS];
-    } else {
-      this.authorizerImplementations = [];
-      this.vaultImplementations = [];
     }
   }
 
@@ -91,14 +68,5 @@ export class NetworkImplementation {
       }
     }
     return address.includes("Authorizer") || address.includes("authorizer");
-  }
-
-  public isVaultImplementation(address: string): boolean {
-    for (let i = 0; i < this.vaultImplementations.length; i++) {
-      if (address.toLowerCase() == this.vaultImplementations[i].toLowerCase()) {
-        return true;
-      }
-    }
-    return !this.isAuthorizerImplementation(address);
   }
 }

--- a/src/networkImplementation.ts
+++ b/src/networkImplementation.ts
@@ -17,6 +17,8 @@ export const POLYGON_AUTHORIZER_IMPLEMENTATION_ADDRESS =
   "0xffffffffffffffffffffffffffffffffffffffff";
 export const MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS =
   "0x2EA0d35d0B1F57C42e6130f298930228bCbFDe9b";
+export const MAINNET_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS =
+  "0xeaD68E489Cb19453b294dc46a3A5710b0d46d17F";
 
 // Vault Implementation Addresses
 // Disable all vault implementations, vault implementations handled by OffchainAssetReceiptVaultBeaconSetDeployer
@@ -45,6 +47,7 @@ export class NetworkImplementation {
     if (network == "mainnet") {
       this.authorizerImplementations = [
         MAINNET_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+        MAINNET_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS,
       ];
       this.vaultImplementations = [MAINNET_VAULT_IMPLEMENTATION_ADDRESS];
     } else if (network == "polygon") {

--- a/tests/handleNewClone.test.ts
+++ b/tests/handleNewClone.test.ts
@@ -6,24 +6,22 @@ import {
   afterEach,
   beforeAll,
   clearInBlockStore,
-  dataSourceMock
+  dataSourceMock,
 } from "matchstick-as";
-import {
-  Address,
-  DataSourceContext,
-  Value
-} from "@graphprotocol/graph-ts";
+import { Address, DataSourceContext, Value } from "@graphprotocol/graph-ts";
 import { handleNewClone } from "../src/CloneFactory";
 import { createNewCloneEvent } from "./mock.test";
-import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS, AMOY_VAULT_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
-
+import { AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS } from "../src/networkImplementation";
 
 describe("Clone Factory Test", () => {
-
   beforeAll(() => {
-    let context = new DataSourceContext()
-    context.set('contextVal', Value.fromI32(325))
-    dataSourceMock.setReturnValues('0xA16081F360e3847006dB660bae1c6d1b2e17eC2A', 'polygon-amoy', context)
+    let context = new DataSourceContext();
+    context.set("contextVal", Value.fromI32(325));
+    dataSourceMock.setReturnValues(
+      "0xA16081F360e3847006dB660bae1c6d1b2e17eC2A",
+      "polygon-amoy",
+      context,
+    );
   });
 
   afterEach(() => {
@@ -32,10 +30,15 @@ describe("Clone Factory Test", () => {
   });
 
   test("handle new authorizer clone", () => {
-
-    const sender = Address.fromString("0x1234567890123456789012345678901234567890");
-    const implementation = Address.fromString(AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS);
-    const clone = Address.fromString("0x1234567890123456789012345678901234567892");
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    const implementation = Address.fromString(
+      AMOY_AUTHORIZER_IMPLEMENTATION_ADDRESS,
+    );
+    const clone = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
     let newCloneEvent = createNewCloneEvent(sender, implementation, clone);
 
     handleNewClone(newCloneEvent);
@@ -47,28 +50,27 @@ describe("Clone Factory Test", () => {
       "Authorizer",
       clone.toHexString(),
       "address",
-      clone.toHexString()
+      clone.toHexString(),
     );
 
-    assert.fieldEquals(
-      "Authorizer",
-      clone.toHexString(),
-      "isActive",
-      "true"
-    );
-    
+    assert.fieldEquals("Authorizer", clone.toHexString(), "isActive", "true");
   });
 
-  test("handle new vault clone", () => {
-    const sender = Address.fromString("0x1234567890123456789012345678901234567890");
-    const implementation = Address.fromString(AMOY_VAULT_IMPLEMENTATION_ADDRESS);
-    const clone = Address.fromString("0x1234567890123456789012345678901234567892");
+  test("handle non-authorizer clone is ignored", () => {
+    const sender = Address.fromString(
+      "0x1234567890123456789012345678901234567890",
+    );
+    // Vault clones are not indexed via CloneFactory (StoxUnifiedDeployer handles vaults)
+    const implementation = Address.fromString(
+      "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    );
+    const clone = Address.fromString(
+      "0x1234567890123456789012345678901234567892",
+    );
     let newCloneEvent = createNewCloneEvent(sender, implementation, clone);
 
     handleNewClone(newCloneEvent);
 
-    // Vault clones are not handled by CloneFactory - they are handled by StoxUnifiedDeployer
-    // So no entities should be created
     assert.entityCount("OffchainAssetReceiptVault", 0);
     assert.entityCount("Authorizer", 0);
   });


### PR DESCRIPTION
## Summary
- Add `MAINNET_PAYMENT_AUTHORIZER_IMPLEMENTATION_ADDRESS` ([`0xeaD68E…`](https://etherscan.io/address/0xeaD68E489Cb19453b294dc46a3A5710b0d46d17F) — `OffchainAssetReceiptVaultPaymentMintAuthorizerV1`)
- Remove unused vault implementation placeholders (`0xfff…`) and `isVaultImplementation` — vaults are indexed via StoxUnifiedDeployer, not CloneFactory
- Update Matchstick test to assert non-authorizer clones are ignored without relying on dead vault constants

Follow-up to #33 (payment authorizer commit landed after that PR was merged).

## Test plan
- [ ] CI Matchstick suite passes
- [ ] After deploy/re-index, payment-authorizer clones on mainnet appear as `Authorizer` entities